### PR TITLE
Add Red Hat subscription requirement for building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repo builds the images for and runs in a podman pod the following services:
 
 # Pre-requisites
 
+- **Red Hat Developer Subscription** (required for building container images)
+  - Sign up for free at https://developers.redhat.com/register
+  - **Both steps are required:**
+    1. Login to container registry: `podman login registry.access.redhat.com`
+    2. Register your system: `sudo subscription-manager register --username <your-username>`
+  - Verify registration: `subscription-manager status`
 - OCM offline token (you will be prompted with instructions)
 - Gemini API key (you will be prompted with instructions)
 


### PR DESCRIPTION
## Summary
- Added Red Hat Developer subscription requirement documentation to README.md
- Implemented subscription verification checks in build-images.sh script
- Script now validates both subscription-manager registration and container registry login before building

## Changes Made
- Updated README.md with clear Red Hat subscription setup instructions
- Added `check_redhat_subscription()` function to build-images.sh
- Provides helpful error messages when subscription requirements are not met

## Test Plan
- [x] Verify script fails gracefully when subscription-manager is not registered
- [x] Verify script provides clear setup instructions in error messages
- [x] Confirm README documentation is clear and actionable

This addresses the subscription issues encountered during container image builds by ensuring users have proper Red Hat access configured before attempting to build.

🤖 Generated with [Claude Code](https://claude.ai/code)