### PR TITLE
Stop using fork for lightspeed-stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = master
 [submodule "lightspeed-stack"]
 	path = lightspeed-stack
-	url = https://github.com/omertuc/lightspeed-stack
-	branch = ownllama
+	url = https://github.com/lightspeed-core/lightspeed-stack.git
+	branch = main
 [submodule "inspector"]
 	path = inspector
 	url = https://github.com/omertuc/inspector

--- a/Containerfile.add_llama_to_lightspeed
+++ b/Containerfile.add_llama_to_lightspeed
@@ -5,6 +5,8 @@ USER root
 
 ADD ./llama-stack /app-root/llama-stack
 
+RUN python3.12 -m ensurepip
+
 RUN cd /app-root/llama-stack && python3.12 -m pip install --editable .
 
 RUN cd /app-root/ && python3.12 -m pip install .

--- a/lightspeed-stack-patch.diff
+++ b/lightspeed-stack-patch.diff
@@ -1,0 +1,12 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 46f57b5..a55ac80 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,7 +9,6 @@ license = {file = "LICENSE"}
+ dependencies = [
+     "fastapi>=0.115.6",
+     "uvicorn>=0.34.3",
+-    "llama-stack>=0.2.13",
+     "rich>=14.0.0",
+ ]
+ 


### PR DESCRIPTION
We are now using the official lightspeed-core/lightspeed-stack repository, since they bumped their llama-stack dependency to a version that supports Gemini.