### PR TITLE
Fix the query.sh OCM_TOKEN assignment

### DIFF
--- a/query.sh
+++ b/query.sh
@@ -7,9 +7,7 @@ if ! command -v ocm &>/dev/null; then
     exit 1
 fi
 
-OCM_TOKEN=$(ocm token 2>/dev/null)
-
-if [ $? -ne 0 ]; then
+if ! OCM_TOKEN=$(ocm token 2>/dev/null); then
     echo "You are not logged in to OCM. Please run 'ocm login --use-auth-code' and follow the instructions."
     exit 1
 elif [ -z "${OCM_TOKEN}" ]; then


### PR DESCRIPTION
It wasn't working as expected, the script would end abruptly when the user is not logged in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the process for retrieving the OCM token, improving script readability and maintainability without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->