### PR TITLE
Ignore empty user queries in interactive mode

### DIFF
--- a/query.sh
+++ b/query.sh
@@ -54,6 +54,8 @@ if "$INTERACTIVE_MODE"; then
         if [[ "$user_query" == "exit" ]]; then
             echo "Exiting script."
             break
+        elif [[ "$user_query" == "" ]]; then
+            continue
         fi
         send_curl_query "$user_query"
     done


### PR DESCRIPTION
Lightspeed stack runs into an error when it receives an empty prompt, so we should avoid it and just re-prompt the user at the shell script level.