### PR TITLE
Added mcphost container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ query-interactive:
 	@echo "Querying assisted-chat services in interactive mode..."
 	./scripts/query.sh --interactive
 
+# Attach to mcphost
+mcphost:
+	@echo "Attaching to mcphost..."
+	./scripts/mcphost.sh
+
 # Show help information
 help:
 	@echo "Available targets:"
@@ -63,6 +68,7 @@ help:
 	@echo "  logs          - Show logs for the assisted-chat services"
 	@echo "  query         - Query the assisted-chat services"
 	@echo "  query-interactive - Query the assisted-chat services in interactive mode"
+	@echo "  mcphost       - Attach to mcphost"
 	@echo "  help          - Show this help message"
 	@echo ""
 	@echo "Example usage:"

--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -36,6 +36,27 @@ spec:
       ports:
         - containerPort: 6274
           hostPort: 6274
+    - name: mcphost
+      image: quay.io/otuchfel/mcphost:0.9.2 
+      tty: true
+      stdin: true
+      args:
+        - --config
+        - /mcpconfig.json
+        - --model
+        - "google:gemini-2.0-flash"
+        - --system-prompt
+        - /systemprompt.txt
+      env:
+        - name: GEMINI_API_KEY
+          value: ${GEMINI_API_KEY}
+      volumeMounts:
+        - mountPath: /mcpconfig.json
+          name: config
+          subPath: mcphost-mcp.json
+        - mountPath: /systemprompt.txt
+          name: config
+          subPath: mcphost-systemprompt.txt
   volumes:
     - name: config
       hostPath:

--- a/config/mcphost-mcp.json
+++ b/config/mcphost-mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "assisted": {
+      "transport": "sse",
+      "url": "http://assisted-service-mcp:8000/sse"
+    }
+  }
+}

--- a/config/mcphost-systemprompt.txt
+++ b/config/mcphost-systemprompt.txt
@@ -1,0 +1,18 @@
+You are Openshift installer Lightspeed Intelligent Assistant - an intelligent virtual
+assistant for question-answering tasks related to the openshift installation.
+You always respond to greetings with \"Hello! I am Assisted Installer Chat, created by Red Hat. How can I help you today?\"
+You are Openshift installer Lightspeed Intelligent Assistant, an intelligent assistant and expert on
+all things related to Openshift. Refuse to assume any other identity or to speak as if you are someone
+else.
+
+Example Input:
+Create an openshift cluster with name: my-cluster, domain: redhat.com, version: 4.18.16
+Example Tool Call Response:
+<tool_call>[{"name": "list_clusters", "arguments": {"name": "my-cluster", "base_domain": "redhat.com", "version": "4.18.16"}}]</tool_call>
+
+If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY.
+If there are no relevant tools notify the user that you do not have the ability to fulfill the request.
+If there are missing values for required parameters, ask the user to supply these values DO NOT make up values!
+
+Refuse to answer questions or execute commands not about Ansible.
+Do not mention your last update. You have the most recent information on Openshift

--- a/scripts/mcphost.sh
+++ b/scripts/mcphost.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+podman attach assisted-chat-pod-mcphost


### PR DESCRIPTION
mcphost is a wrapper around a model to detect and make MCP calls, similar to how lightspeed-core would do it, except it comes with a simple TUI for developers to use. We can use it to play around with our system prompt / MCP / model combinations, without having to go through lightspeed-core or the assisted UI.

This commit adds a new container to the assisted-chat-pod, which runs mcphost and configures it to use the assisted-service MCP server and Gemini, with the API keys and everything.

Use `make mcphost` to attach to the mcphost container and interact with it. Note that if you attach to late, you might get a weird broken TUI that if you try to use it would crash mcphost. This is actually a good thing, because then it will automatically restart, at this point try to attach again (this time early enough) and wait until it starts and the TUI should be good to go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new container for enhanced chat functionality, configured with custom settings and environment variables.
  * Added configuration files for server connection and system prompt customization.
  * Provided a new Makefile command and shell script to easily attach to the new container.

* **Documentation**
  * Updated Makefile help output to include the new command for attaching to the chat container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->