### PR TITLE
Fix selinux issue

### DIFF
--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -13,7 +13,7 @@ spec:
         - containerPort: 8090
           hostPort: 8090
       volumeMounts:
-        - mountPath: /app-root/lightspeed-stack.yaml
+        - mountPath: /app-root/lightspeed-stack.yaml:Z
           name: config
           subPath: lightspeed-stack.yaml
         - mountPath: /app-root/llama_stack_client_config.yaml


### PR DESCRIPTION
The `lightspeed-stack.yaml` mount needs to be mounted with the :Z option, otherwise selinux needs to be disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security context for a mounted volume to improve shared access within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->