### PR TITLE
gemini secret key was created with underscore

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -245,7 +245,7 @@ objects:
             valueFrom:
               secretKeyRef:
                 name: ${GEMINI_API_SECRET_NAME}
-                key: api-key
+                key: api_key
           - name: LLAMA_STACK_SQLITE_STORE_DIR
             value: ${STORAGE_MOUNT_PATH}/sqlite
           - name: LLAMA_STACK_OTEL_SERVICE_NAME


### PR DESCRIPTION
gemini secret key was created with underscore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the reference name for the Gemini API key in the deployment environment variables. No other configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->