### PR TITLE
route for lightspeed-stack

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,12 @@ parameters:
 - name: REPLICAS_COUNT
   value: "1"
   description: "Number of pod replicas to deploy for high availability"
+- name: ROUTE_HOST
+  value: "api.openshift.com"
+  description: "Hostname for the OpenShift route to access the chat interface"
+- name: ROUTE_PATH
+  value: "/api/assisted_chat"
+  description: "Path for the OpenShift route to access the chat interface"
 - name: SERVICE_PORT
   value: "8090"
   description: "Port number on which the lightspeed-stack service listens"
@@ -301,3 +307,22 @@ objects:
       protocol: TCP
     selector:
       app: assisted-chat
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: assisted-chat
+    labels:
+      app: assisted-chat
+  spec:
+    host: ${ROUTE_HOST}
+    path: ${ROUTE_PATH}
+    to:
+      kind: Service
+      name: assisted-chat
+      weight: 100
+    port:
+      targetPort: http
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Route for accessing the chat service externally (by default via https://api.openshift.com/api/assisted_chat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring hostname and path for accessing the chat interface via new parameters.
  * Introduced a new OpenShift Route for secure (HTTPS) external access to the chat interface, with automatic HTTP to HTTPS redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->