### PR TITLE
Fix MCP token authentication

### DIFF
--- a/lightspeed-stack.template.yaml
+++ b/lightspeed-stack.template.yaml
@@ -17,3 +17,5 @@ user_data_collection:
   feedback_storage: "/tmp/data/feedback"
   transcripts_disabled: false
   transcripts_storage: "/tmp/data/transcripts"
+authentication:
+  module: "noop-with-token"


### PR DESCRIPTION
See https://github.com/lightspeed-core/lightspeed-stack/pull/220

This commit moves us to use that new PR, and uses the `noop-with-token` authentication module which handles extracting the token from the Authorization header.