### PR TITLE
refining readiness probe periods

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4,7 +4,7 @@ parameters:
   value: "quay.io/lightspeed-core/lightspeed-stack"
   description: "Container image for the lightspeed-stack application"
 - name: IMAGE_TAG
-  value: ''
+  value: ""
   required: true
   description: "Tag of the container image to deploy"
 - name: MCP_SERVER_URL
@@ -281,8 +281,8 @@ objects:
             httpGet:
               path: /v1/readiness
               port: ${{SERVICE_PORT}}
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
         volumes:
         - name: lightspeed-config
           configMap:


### PR DESCRIPTION

Reduced the frequency of readiness probes, as the original settings led to `RuntimeError: can't start new thread` errors after a few hours in low-resource environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default value format for the image tag parameter.
  * Adjusted readiness probe settings to delay the initial check and reduce the frequency of subsequent checks during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->