### PR TITLE
Add JWT validation with Envoy sidecar

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -85,6 +85,21 @@ parameters:
   value: "8321"
   description: "Port number for the embedded Llama Stack server"
 
+- name: ENVOY_IMAGE
+  value: "envoyproxy/envoy"
+  required: false
+- name: ENVOY_TAG
+  value: "v1.34.2"
+  required: false
+- name: ENVOY_MEMORY_REQUEST
+  value: "256Mi"
+- name: ENVOY_MEMORY_LIMIT
+  value: "512Mi"
+- name: ENVOY_CPU_REQUEST
+  value: "10m"
+- name: ENVOY_CPU_LIMIT
+  value: "1000m"
+
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -105,7 +120,7 @@ objects:
       name: ${LIGHTSPEED_NAME}
       service:
         host: 0.0.0.0
-        port: ${SERVICE_PORT}
+        port: 9000
         auth_enabled: ${LIGHTSPEED_SERVICE_AUTH_ENABLED}
         workers: ${LIGHTSPEED_SERVICE_WORKERS}
         color_log: ${LIGHTSPEED_SERVICE_COLOR_LOG}
@@ -245,6 +260,120 @@ objects:
       server:
         port: ${LLAMA_STACK_SERVER_PORT}
 
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: assisted-chat-envoy-config
+    labels:
+      app: assisted-chat
+  data:
+    main.yaml: |
+      admin:
+        access_log_path: /dev/stdout
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 10000
+
+      static_resources:
+
+        clusters:
+
+        - name: backend
+          connect_timeout: 1s
+          type: static
+          lb_policy: random
+          load_assignment:
+            cluster_name: backend
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 9000
+
+        - name: sso_redhat_com
+          connect_timeout: 5s
+          type: strict_dns
+          dns_lookup_family: v4_only
+          lb_policy: random
+          load_assignment:
+            cluster_name: sso_redhat_com
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: sso.redhat.com
+                      port_value: 443
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: sso.redhat.com
+
+        listeners:
+
+        - name: ingress
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: ${SERVICE_PORT}
+          filter_chains:
+            filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    path: /dev/stdout
+                stat_prefix: ingress
+                http_filters:
+
+                - name: envoy.filters.http.jwt_authn
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                    providers:
+                      sso_redhat_com:
+                        issuer: https://sso.redhat.com/auth/realms/redhat-external
+                        audiences: []
+                        remote_jwks:
+                          http_uri:
+                            uri: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
+                            cluster: sso_redhat_com
+                            timeout: 5s
+                          cache_duration: 300s
+                        forward: true
+                        from_headers:
+                        - name: Authorization
+                          value_prefix: "Bearer "
+                    rules:
+                    - match:
+                        prefix: /
+                      requires:
+                        provider_name: sso_redhat_com
+
+                - name: envoy.filters.http.router
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+                route_config:
+                  name: ingress
+                  virtual_hosts:
+                  - name: all
+                    domains:
+                    - "*"
+                    routes:
+                    - name: all
+                      match:
+                        prefix: /api/assisted_chat/
+                      route:
+                        cluster: backend
+                        timeout: 300s
+
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -262,13 +391,10 @@ objects:
           app: assisted-chat
       spec:
         containers:
+
         - name: lightspeed-stack
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
-          ports:
-          - name: http
-            containerPort: ${{SERVICE_PORT}}
-            protocol: TCP
           env:
           - name: GEMINI_API_KEY
             valueFrom:
@@ -305,16 +431,53 @@ objects:
           livenessProbe:
             httpGet:
               path: /v1/liveness
-              port: ${{SERVICE_PORT}}
+              port: 9000
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /v1/readiness
-              port: ${{SERVICE_PORT}}
+              port: 9000
             initialDelaySeconds: 30
             periodSeconds: 10
+
+        - name: envoy-sidecar
+          image: ${ENVOY_IMAGE}:${ENVOY_TAG}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: envoy-config
+            mountPath: /configs/envoy
+          command:
+          - envoy
+          - --config-path
+          - /configs/envoy/main.yaml
+          ports:
+          - name: http
+            protocol: TCP
+            containerPort: ${{SERVICE_PORT}}
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 10000
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 10000
+            initialDelaySeconds: 5
+          resources:
+            requests:
+              memory: ${ENVOY_MEMORY_REQUEST}
+              cpu: ${ENVOY_CPU_REQUEST}
+            limits:
+              memory: ${ENVOY_MEMORY_LIMIT}
+              cpu: ${ENVOY_CPU_LIMIT}
+
+
         volumes:
+        - name: envoy-config
+          configMap:
+            name: assisted-chat-envoy-config
         - name: lightspeed-config
           configMap:
             name: lightspeed-stack-config


### PR DESCRIPTION
This patch adds an Envoy sidecar to the assisted-chat pod. It is configured to extract JSON web tokens from the `Authorization` header and validate them against the `redhat-external` ream of _sso.redhat.com_.