### PR TITLE
Make OpenShift service headless

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -331,6 +331,7 @@ objects:
     labels:
       app: assisted-chat
   spec:
+    clusterIP: None
     ports:
     - name: http
       port: ${{SERVICE_PORT}}


### PR DESCRIPTION
This patch changes the service created by the OpenShift template so that it will be headless. This means that when clients resolve the name in DNS they will get directly the IPs of the pods, and not the single IP of the service. This is necessary because will be sending traffic from an Envoy proxy that needs to see the IP addresses of the pods in order to implement stateful sessions.

Related: https://issues.redhat.com/browse/MGMT-21166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the assisted-chat service configuration to use a headless service for improved service discovery within the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->