### PR TITLE
recycle pods after configmap changes

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -350,8 +350,6 @@ objects:
             value: ${LLAMA_STACK_OTEL_SERVICE_NAME}
           - name: LLAMA_STACK_TELEMETRY_SINKS
             value: ${LLAMA_STACK_TELEMETRY_SINKS}
-          - name: DEPLOY_VERSION
-            value: "3"
           resources:
             limits:
               memory: ${MEMORY_LIMIT}

--- a/template.yaml
+++ b/template.yaml
@@ -96,6 +96,8 @@ objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
+    annotations:
+      qontract.recycle: "true"
     name: lightspeed-stack-config
     labels:
       app: assisted-chat
@@ -216,6 +218,8 @@ objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
+    annotations:
+      qontract.recycle: "true"
     name: llama-stack-client-config
     labels:
       app: assisted-chat


### PR DESCRIPTION
from [app-interface](https://gitlab.cee.redhat.com/service/app-interface#manage-openshift-resources-via-app-interface-openshiftnamespace-1yml):
> If a resource has a qontract.recycle: "true" annotation, all pods using that resource will be recycled on every update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to improve management of certain application resources. No impact on application features or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->