### PR TITLE
Use an older lightspeed stack tag

### DIFF
--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -1,5 +1,5 @@
 # vim: set filetype=dockerfile
-FROM quay.io/lightspeed-core/lightspeed-stack:dev-latest
+FROM quay.io/lightspeed-core/lightspeed-stack:dev-20250718-0cb49fc
 
 RUN python3 -m ensurepip --default-pip && pip install --upgrade pip
 


### PR DESCRIPTION
The "dev-latest" tag was failing when we tried to run, but this tag matches the commit of our submodule and the patch applies cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image in the container configuration to use a specific version tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->