### PR TITLE
Keep renovate submodule PRs for some repos

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignoreDeps": [
+    // llama-stack and lightspeed-stack must be updated together, as lightspeed-stack
+    // expects a very specific version of llama-stack, so we exclude them from auto-updates
+    // because any PR that updates one must also update the other, so it has to be done manually.
+    "llama-stack",
+    "lightspeed-stack",
+    // We don't particularly care about updating inspector
+    "inspector"
+  ],
   "git-submodules": {
-    "enabled": false
+    "enabled": true
   }
 }


### PR DESCRIPTION
It would still be nice to get PRs for the UI repo and the MCP repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings to enable automatic updates for git submodules.
  * Excluded specific dependencies from automatic updates based on project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->