### PR TITLE
Switch to using token authentication

### DIFF
--- a/lightspeed-stack.template.yaml
+++ b/lightspeed-stack.template.yaml
@@ -18,7 +18,12 @@ user_data_collection:
   transcripts_disabled: false
   transcripts_storage: "/tmp/data/transcripts"
 authentication:
-  module: "noop-with-token"
+  module: jwk-token
+  jwk_config:
+    url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
+    jwt_configuration:
+      user_id_claim: user_id
+      username_claim: username
 customization:
   system_prompt_path: "/tmp/systemprompt.txt"
   disable_query_system_prompt: false

--- a/template.yaml
+++ b/template.yaml
@@ -116,7 +116,12 @@ objects:
         use_as_library_client: true
         library_client_config_path: "/app-root/llama_stack_client_config.yaml"
       authentication:
-        module: "noop-with-token"
+        module: jwk-token
+        jwk_config:
+          url: ${SSO_BASE_URL}/protocol/openid-connect/certs
+          jwt_configuration:
+            user_id_claim: user_id
+            username_claim: username
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"


### PR DESCRIPTION
Update lightspeed-stack to the latest version which includes this PR:

https://github.com/lightspeed-core/lightspeed-stack/pull/243

Modify our configuration to use the new jwk-token authentication module, with the JWK URL pointing to the Red Hat SSO server and using the user ID / username fields that can be found in a typical JWT issued by Red Hat SSO.