### PR TITLE
SSO_BASE_URL doesn't get replaced by app-interface

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -118,7 +118,7 @@ objects:
       authentication:
         module: jwk-token
         jwk_config:
-          url: ${SSO_BASE_URL}/protocol/openid-connect/certs
+          url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
           jwt_configuration:
             user_id_claim: user_id
             username_claim: username


### PR DESCRIPTION
Just use the explicit domain for now.

```
File "/app-root/src/lightspeed_stack.py", line 91, in <module>
main()
File "/app-root/src/lightspeed_stack.py", line 67, in main
configuration.load_configuration(args.config_file)
File "/app-root/src/configuration.py", line 41, in load_configuration
self.init_from_dict(config_dict)
File "/app-root/src/configuration.py", line 45, in init_from_dict
self._configuration = Configuration(**config_dict)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app-root/.venv/lib64/python3.12/site-packages/pydantic/main.py", line 253, in __init__
validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Configuration
authentication.jwk_config.url
Input should be a valid URL, relative URL without a base [type=url_parsing, input_value='${SSO_BASE_URL}/protocol/openid-connect/certs', input_type=str]
For further information visit https://errors.pydantic.dev/2.11/v/url_parsing
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the authentication module to use a fixed JWK URL for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->