### PR TITLE
MGMT-21336 Query fail when a model isn't provided in the request

### DIFF
--- a/lightspeed-stack.template.yaml
+++ b/lightspeed-stack.template.yaml
@@ -27,3 +27,6 @@ authentication:
 customization:
   system_prompt_path: "/tmp/systemprompt.txt"
   disable_query_system_prompt: false
+inference:
+  default_model: gemini/gemini/gemini-2.0-flash
+  default_provider: gemini


### PR DESCRIPTION
Specify the default model and provider in the LSC config

This is required because following
https://github.com/meta-llama/llama-stack/pull/2886 llama-stack discovers the models dynamically, if we don't pass a provider and model, it falls back to the first model it finds (regardless of what we have in the llama-stack config.yaml)

Note that it's also listing vertexAI models (which work with the vertexAI API)!