### PR TITLE
MGMT-21271: Increase lightspeed pod probe timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -421,12 +421,14 @@ objects:
               port: ${{SERVICE_PORT}}
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 2
           readinessProbe:
             httpGet:
               path: /readiness
               port: ${{SERVICE_PORT}}
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 2
         volumes:
         - name: lightspeed-config
           configMap:


### PR DESCRIPTION
Currently the value is at one second (the default), but we're seeing significant failures for both probes causing outages. Doubling it for now since this should be fast and continuing to monitor the pods.

https://issues.redhat.com/browse/MGMT-21271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application health checks to use a 2-second timeout for improved reliability during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->