### PR TITLE
MGMT-21271: Add more workers

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -45,7 +45,7 @@ parameters:
   value: "assisted-chat"
   description: "Name identifier for the lightspeed service instance"
 - name: LIGHTSPEED_SERVICE_WORKERS
-  value: "1"
+  value: "10"
   description: "Number of worker processes for the lightspeed service"
 - name: LIGHTSPEED_SERVICE_AUTH_ENABLED
   value: "false"


### PR DESCRIPTION
Probes are still failing even with the added timeout Some more workers will probably help

https://issues.redhat.com/browse/MGMT-21271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default number of worker processes for the lightspeed service from 1 to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->