### PR TITLE
MGMT-21271: Revert "Add more workers"

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -45,7 +45,7 @@ parameters:
   value: "assisted-chat"
   description: "Name identifier for the lightspeed service instance"
 - name: LIGHTSPEED_SERVICE_WORKERS
-  value: "10"
+  value: "1"
   description: "Number of worker processes for the lightspeed service"
 - name: LIGHTSPEED_SERVICE_AUTH_ENABLED
   value: "false"


### PR DESCRIPTION
This reverts commit bfb3164b76a359e1133cbb80eb08585479464a27.

This is failing due to https://issues.redhat.com/browse/LCORE-455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default number of worker processes for the lightspeed service from 10 to 1 in the configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->