### PR TITLE
Use `sub` and `preferred_username` as claims

### DIFF
--- a/lightspeed-stack.template.yaml
+++ b/lightspeed-stack.template.yaml
@@ -22,8 +22,8 @@ authentication:
   jwk_config:
     url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
     jwt_configuration:
-      user_id_claim: user_id
-      username_claim: username
+      user_id_claim: sub
+      username_claim: preferred_username
 customization:
   system_prompt_path: "/tmp/systemprompt.txt"
   disable_query_system_prompt: false

--- a/template.yaml
+++ b/template.yaml
@@ -129,8 +129,8 @@ objects:
         jwk_config:
           url: ${SSO_BASE_URL}/protocol/openid-connect/certs
           jwt_configuration:
-            user_id_claim: user_id
-            username_claim: username
+            user_id_claim: sub
+            username_claim: preferred_username
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"


### PR DESCRIPTION
We currently use `user_id` and `username` as claims in the authentication configuration of the Lightspeed stack. These claims are not available in service account tokens, which are used by our CI.

Instead we should use `sub` and `preferred_username`, which are available in both user and service account tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated JWT authentication configuration to use new claim names for user ID and username. This may affect how user information is displayed or processed during authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->