### PR TITLE
add ocm-mcp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,10 @@
 	path = assisted-service-mcp
 	url = https://github.com/openshift-assisted/assisted-service-mcp
 	branch = master
+[submodule "ocm-mcp"]
+	path = ocm-mcp
+	url = https://github.com/redhat-ai-tools/ocm-mcp
+	branch = main
 [submodule "lightspeed-stack"]
 	path = lightspeed-stack
 	url = https://github.com/lightspeed-core/lightspeed-stack.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This repo builds the images for and runs in a podman pod the following services:
 - [x] assisted-service-mcp
+- [x] ocm-mcp
 - [x] lightspeed-core + llama-stack (Same container, built separately)
 - [x] assisted UI
 - [x] inspector

--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -34,6 +34,8 @@ spec:
           subPath: systemprompt.txt
     - name: assisted-service-mcp
       image: localhost/local-ai-chat-assisted-service-mcp:latest
+    - name: ocm-mcp
+      image: localhost/local-ai-chat-ocm-mcp:latest
     - name: ui
       image: localhost/local-ai-chat-ui
       env:

--- a/config/llama_stack_client_config.yaml
+++ b/config/llama_stack_client_config.yaml
@@ -104,5 +104,9 @@ tool_groups:
   provider_id: model-context-protocol
   mcp_endpoint:
     uri: "http://assisted-service-mcp:8000/sse"
+- toolgroup_id: mcp::ocm
+  provider_id: model-context-protocol
+  mcp_endpoint:
+    uri: "http://ocm-mcp:8000/sse"
 server:
   port: 8321

--- a/config/mcphost-mcp.json
+++ b/config/mcphost-mcp.json
@@ -4,6 +4,11 @@
       "transport": "sse",
       "url": "http://assisted-service-mcp:8000/sse",
       "headers": ["Authorization: Bearer ${env://OCM_TOKEN}"]
+    },
+    "ocm": {
+      "transport": "sse",
+      "url": "http://ocm-mcp:8000/sse",
+      "headers": ["Authorization: Bearer ${env://OCM_TOKEN}"]
     }
   }
 }

--- a/lightspeed-stack.template.yaml
+++ b/lightspeed-stack.template.yaml
@@ -12,6 +12,8 @@ llama_stack:
 mcp_servers:
   - name: mcp::assisted
     url: "http://assisted-service-mcp:8000/sse"
+  - name: mcp::ocm
+    url: "http://ocm-mcp:8000/sse"
 user_data_collection:
   feedback_disabled: false
   feedback_storage: "/tmp/data/feedback"

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -7,6 +7,7 @@ PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
 
 if [[ ! -d "${PROJECT_ROOT}/inspector" ||
     ! -d "${PROJECT_ROOT}/assisted-service-mcp" ||
+    ! -d "${PROJECT_ROOT}/ocm-mcp" ||
     ! -d "${PROJECT_ROOT}/assisted-installer-ui/" ||
     ! -d "${PROJECT_ROOT}/lightspeed-stack" ]]; then
     echo "Dependency directories do not exist. Load git submodules first."
@@ -25,6 +26,7 @@ OPTIONS:
 IMAGES:
     inspector                   Build the inspector image
     assisted-mcp                Build the assisted service MCP image
+    ocm-mcp                     Build the OCM MCP image
     lightspeed-stack            Build the lightspeed stack image
     lightspeed-plus-llama-stack Build the lightspeed stack plus llama stack image
     ui                          Build the UI image
@@ -78,6 +80,14 @@ function build_assisted_mcp() {
     echo "✓ Assisted service MCP image built successfully"
 }
 
+function build_ocm_mcp() {
+    echo "Building OCM MCP image..."
+    pushd "${PROJECT_ROOT}/ocm-mcp"
+    make build IMAGE_NAME=localhost/local-ai-chat-ocm-mcp TAG=latest
+    popd
+    echo "✓ OCM MCP image built successfully"
+}
+
 function build_lightspeed_stack() {
     echo "Building lightspeed stack image..."
     pushd "${PROJECT_ROOT}/lightspeed-stack"
@@ -124,7 +134,7 @@ while [[ $# -gt 0 ]]; do
             show_usage
             exit 0
             ;;
-        inspector|assisted-mcp|lightspeed-stack|lightspeed-plus-llama-stack|ui|all)
+        inspector|assisted-mcp|ocm-mcp|lightspeed-stack|lightspeed-plus-llama-stack|ui|all)
             IMAGES_TO_BUILD+=("$1")
             shift
             ;;
@@ -142,7 +152,7 @@ if [[ ${#IMAGES_TO_BUILD[@]} -eq 0 ]]; then
 fi
 
 # Verify Red Hat subscription before building
-check_redhat_subscription
+# check_redhat_subscription
 
 # Build requested images
 for image in "${IMAGES_TO_BUILD[@]}"; do
@@ -152,6 +162,9 @@ for image in "${IMAGES_TO_BUILD[@]}"; do
             ;;
         assisted-mcp)
             build_assisted_mcp
+            ;;
+        ocm-mcp)
+            build_ocm_mcp
             ;;
         lightspeed-stack)
             build_lightspeed_stack
@@ -165,6 +178,7 @@ for image in "${IMAGES_TO_BUILD[@]}"; do
         all)
             build_inspector
             build_assisted_mcp
+            build_ocm_mcp
             build_lightspeed_stack
             build_lightspeed_stack_plus_llama_stack
             build_ui

--- a/template.yaml
+++ b/template.yaml
@@ -10,6 +10,9 @@ parameters:
 - name: MCP_SERVER_URL
   value: "http://assisted-service-mcp:8000/sse"
   description: "URL for the Model Context Protocol (MCP) server that provides assisted installer functionality"
+- name: OCM_MCP_SERVER_URL
+  value: "http://ocm-mcp:8000/sse"
+  description: "URL for the Model Context Protocol (MCP) server that provides managed openshift functionality"
 - name: REPLICAS_COUNT
   value: "1"
   description: "Number of pod replicas to deploy for high availability"
@@ -134,6 +137,8 @@ objects:
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"
+        - name: ocm::mcp
+          url: "${OCM_MCP_SERVER_URL}"
       user_data_collection:
         feedback_disabled: ${LIGHTSPEED_FEEDBACK_DISABLED}
         feedback_storage: "${STORAGE_MOUNT_PATH}/feedback"
@@ -146,7 +151,7 @@ objects:
         default_model: "${LLAMA_STACK_INFERENCE_PROVIDER}/${LLAMA_STACK_2_0_FLASH_MODEL}"
         default_provider: ${LLAMA_STACK_INFERENCE_PROVIDER}
     system_prompt: |
-      You are OpenShift Lightspeed Intelligent Assistant - an intelligent virtual assistant and expert on all things related to OpenShift installation, configuration, and troubleshooting, specifically with the Assisted Installer.
+      You are OpenShift Lightspeed Intelligent Assistant - an intelligent virtual assistant and expert on all things related to OpenShift installation, configuration, and troubleshooting, specifically with the Assisted Installer and Managed OpenShift (ROSA/OSD).
 
       **Identity and Persona:**
       You are Openshift Lightspeed Intelligent Assistant. Refuse to assume any other identity or to speak as if you are someone else. Maintain a helpful, clear, and direct tone.
@@ -158,11 +163,11 @@ objects:
 
       ---
 
-      **Proactive OpenShift Assisted Installer Workflow Guidance:**
+      **Proactive OpenShift Provisioning Workflow Guidance:**
 
-      Your primary goal is to guide the user through the OpenShift Assisted Installer process. Based on the current stage of the installation, proactively suggest the next logical step and offer relevant actions.
+      Your primary goal is to guide the user through the OpenShift provisioning process, for either Assisted Installer or Managed OpenShift (ROSA/OSD). Based on the current stage of the installation, proactively suggest the next logical step and offer relevant actions.
 
-      The typical Assisted Installer flow involves these stages:
+      The typical provisioning flow involves these stages:
 
       1.  **Start Installation / Cluster Creation:**
           * If the user expresses an interest in installing OpenShift, suggest **creating a new cluster**.
@@ -326,6 +331,10 @@ objects:
         provider_id: model-context-protocol
         mcp_endpoint:
           uri: "${MCP_SERVER_URL}"
+      - toolgroup_id: mcp::ocm
+        provider_id: model-context-protocol
+        mcp_endpoint:
+          uri: "${OCM_MCP_SERVER_URL}"
       server:
         port: ${LLAMA_STACK_SERVER_PORT}
 

--- a/template.yaml
+++ b/template.yaml
@@ -137,7 +137,7 @@ objects:
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"
-        - name: ocm::mcp
+        - name: mcp::ocm
           url: "${OCM_MCP_SERVER_URL}"
       user_data_collection:
         feedback_disabled: ${LIGHTSPEED_FEEDBACK_DISABLED}


### PR DESCRIPTION
this PR adds an OCM MCP server from https://github.com/redhat-ai-tools/ocm-mcp.

this should provide initial capabilities to work against managed openshift.

related to https://github.com/redhat-ai-tools/ocm-mcp/pull/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "ocm-mcp" service, including configuration, container image, and pod integration.
  * Enhanced system prompts and workflow guidance to include Managed OpenShift (ROSA/OSD) expertise alongside Assisted Installer.
  * Introduced new configuration parameters and endpoints for Managed OpenShift functionality.

* **Documentation**
  * Updated README to include "ocm-mcp" in the list of managed services.

* **Chores**
  * Added "ocm-mcp" as a git submodule for streamlined development and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->