### PR TITLE
fixing the image digest for task-rpm-signature-scan

### DIFF
--- a/.tekton/assisted-chat-saas-main-pull-request.yaml
+++ b/.tekton/assisted-chat-saas-main-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:cb63fdce49a460891963febcfe1d24783dc9348f9350cf2f61d7231c64aa8684
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-chat-saas-main-push.yaml
+++ b/.tekton/assisted-chat-saas-main-push.yaml
@@ -582,7 +582,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:cb63fdce49a460891963febcfe1d24783dc9348f9350cf2f61d7231c64aa8684
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
fixing the image digest for task-rpm-signature-scan in the tekton pipelines so would not need to wait till the automatic PR created by Konflux