### PR TITLE
MGMT-21239: creating an image which could be started in the cluster claimed by prow

### DIFF
--- a/test/prow/Dockerfile
+++ b/test/prow/Dockerfile
@@ -1,5 +1,6 @@
-FROM ocp/ubi-python-311:9
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
+USER 0
 RUN yum install -y jq patch
 RUN pip install git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
 RUN mkdir -p /opt/app-root/src


### PR DESCRIPTION
[MGMT-21239](https://issues.redhat.com//browse/MGMT-21239): creating an image which could be started in the cluster claimed by prow and is hosting the eval-tests and everything needed to run them. Also patching the template, because with postgres it does not work.
