### PR TITLE
MGMT-21239: creating an image which could be started in the cluster claimed by prow

### DIFF
--- a/test/evals/eval.py
+++ b/test/evals/eval.py
@@ -18,16 +18,63 @@ logging.getLogger("lsc_agent_eval").setLevel(logging.INFO)
 
 
 # Create proper Namespace object for AgentGoalEval
-args = argparse.Namespace()
-args.eval_data_yaml = "eval_data.yaml"
-args.agent_endpoint = "http://localhost:8090"
-args.agent_provider = "gemini"
-args.agent_model = "gemini/gemini-2.5-flash"
-# Set up judge model for LLM evaluation
-args.judge_provider = "gemini"
-args.judge_model = "gemini-2.5-flash"
-args.agent_auth_token_file = "ocm_token.txt"
-args.result_dir = "eval_output"
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Agent goal evaluation")
+    
+    parser.add_argument(
+        "--eval_data_yaml",
+        default="eval_data.yaml",
+        help="Path to evaluation data YAML file (default: eval_data.yaml)"
+    )
+    
+    parser.add_argument(
+        "--agent_endpoint",
+        default="http://localhost:8090",
+        help="Agent endpoint URL (default: http://localhost:8090)"
+    )
+    
+    parser.add_argument(
+        "--agent_provider",
+        default="gemini",
+        help="Agent provider (default: gemini)"
+    )
+    
+    parser.add_argument(
+        "--agent_model",
+        default="gemini/gemini-2.5-flash",
+        help="Agent model (default: gemini/gemini-2.5-flash)"
+    )
+    
+    parser.add_argument(
+        "--judge_provider",
+        default="gemini",
+        help="Judge provider for LLM evaluation (default: gemini)"
+    )
+    
+    parser.add_argument(
+        "--judge_model",
+        default="gemini-2.5-flash",
+        help="Judge model for LLM evaluation (default: gemini-2.5-flash)"
+    )
+    
+    parser.add_argument(
+        "--agent_auth_token_file",
+        default="ocm_token.txt",
+        help="Path to agent auth token file (default: ocm_token.txt)"
+    )
+    
+    parser.add_argument(
+        "--result_dir",
+        default="eval_output",
+        help="Directory for evaluation results (default: eval_output)"
+    )
+    
+    return parser.parse_args()
+
+
+# Parse command line arguments
+args = parse_args()
 
 evaluator = AgentGoalEval(args)
 # Run Evaluation

--- a/test/prow/Dockerfile
+++ b/test/prow/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/python-311:latest
+
+USER 0
+RUN yum install -y jq patch
+RUN pip install git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
+RUN mkdir -p /opt/app-root/src
+WORKDIR /opt/app-root/src
+COPY . .
+RUN chmod 755 test/prow/entrypoint.sh
+
+ENTRYPOINT [ "/opt/app-root/src/test/prow/entrypoint.sh" ]

--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+
+OCM_TOKEN=$(curl -X POST https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$CLIENT_SECRET" | jq '.access_token')
+
+echo $OCM_TOKEN > test/evals/ocm_token.txt
+
+cd test/evals
+
+python eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}"

--- a/test/prow/template.yaml
+++ b/test/prow/template.yaml
@@ -1,0 +1,80 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: assisted-chat-eval-test
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: assisted-chat-eval-test
+  spec:
+    selector:
+      matchLabels:
+        app: assisted-chat-eval-test
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: assisted-chat-eval-test
+      spec:
+        restartPolicy: Always
+        containers:
+        - name: assisted-chat-eval-test
+          image: ${IMAGE_NAME}
+          imagePullPolicy: Always
+          env:
+          - name: CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: ${SSL_CLIENT_ID}
+                name: ${SSL_CLIENT_SECRET_NAME}
+          - name: CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: ${SSL_CLIENT_SECRET_KEY}
+                name: ${SSL_CLIENT_SECRET_NAME}
+          - name: GEMINI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: ${GEMINI_API_SECRET_KEY_NAME}
+                name: ${GEMINI_API_SECRET_NAME}
+          - name: AGENT_URL
+            value: ${AGENT_URL}
+          - name: AGENT_PORT
+            value: ${AGENT_PORT}
+
+        
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: assisted-chat-eval-test
+    name: assisted-chat-eval-test
+  spec:
+    ports:
+    - port: 8091
+      protocol: TCP
+      targetPort: 8091
+    selector:
+      app: assisted-chat-eval-test
+    sessionAffinity: None
+    type: ClusterIP
+
+parameters:
+- name: IMAGE_NAME
+  required: true
+- name: SSL_CLIENT_SECRET_NAME
+  value: assisted-chat-ssl-ci
+- name: SSL_CLIENT_ID
+  value: client_id
+- name: SSL_CLIENT_SECRET_KEY
+  value: client_secret
+- name: AGENT_URL
+  value: http://assisted-chat
+- name: AGENT_PORT
+  value: "8090"
+- name: GEMINI_API_SECRET_NAME
+  value: gemini
+- name: GEMINI_API_SECRET_KEY_NAME
+  value: api_key
+

--- a/test/prow/template_patch.diff
+++ b/test/prow/template_patch.diff
@@ -1,0 +1,52 @@
+--- template.yaml	2025-08-07 13:21:45.653132384 +0200
++++ template.yaml	2025-08-07 13:36:12.358207999 +0200
+@@ -247,19 +247,12 @@
+           provider_type: inline::meta-reference
+           config:
+             persistence_store:
+-              type: postgres
+-              host: ${env.LLAMA_STACK_POSTGRES_HOST}
+-              port: ${env.LLAMA_STACK_POSTGRES_PORT}
+-              db: ${env.LLAMA_STACK_POSTGRES_NAME}
+-              user: ${env.LLAMA_STACK_POSTGRES_USER}
+-              password: ${env.LLAMA_STACK_POSTGRES_PASSWORD}
++              type: sqlite
++              namespace: null
++              db_path: ${STORAGE_MOUNT_PATH}/sqlite/agents_store.db
+             responses_store:
+-              type: postgres
+-              host: ${env.LLAMA_STACK_POSTGRES_HOST}
+-              port: ${env.LLAMA_STACK_POSTGRES_PORT}
+-              db: ${env.LLAMA_STACK_POSTGRES_NAME}
+-              user: ${env.LLAMA_STACK_POSTGRES_USER}
+-              password: ${env.LLAMA_STACK_POSTGRES_PASSWORD}
++              type: sqlite
++              db_path: ${STORAGE_MOUNT_PATH}/sqlite/responses_store.db
+         telemetry:
+         - provider_id: meta-reference
+           provider_type: inline::meta-reference
+@@ -284,20 +277,11 @@
+           provider_type: remote::model-context-protocol
+           config: {}
+       metadata_store:
+-        type: postgres
+-        host: ${env.LLAMA_STACK_POSTGRES_HOST}
+-        port: ${env.LLAMA_STACK_POSTGRES_PORT}
+-        db: ${env.LLAMA_STACK_POSTGRES_NAME}
+-        user: ${env.LLAMA_STACK_POSTGRES_USER}
+-        password: ${env.LLAMA_STACK_POSTGRES_PASSWORD}
+-        table_name: llamastack_kvstore
++        type: sqlite
++        db_path: ${STORAGE_MOUNT_PATH}/sqlite/registry.db
+       inference_store:
+-        type: postgres
+-        host: ${env.LLAMA_STACK_POSTGRES_HOST}
+-        port: ${env.LLAMA_STACK_POSTGRES_PORT}
+-        db: ${env.LLAMA_STACK_POSTGRES_NAME}
+-        user: ${env.LLAMA_STACK_POSTGRES_USER}
+-        password: ${env.LLAMA_STACK_POSTGRES_PASSWORD}
++        type: sqlite
++        db_path: ${STORAGE_MOUNT_PATH}/sqlite/inference_store.db
+       models:
+       - metadata: {}
+         model_id: ${LLAMA_STACK_2_0_FLASH_MODEL}


### PR DESCRIPTION
[MGMT-21239](https://issues.redhat.com//browse/MGMT-21239): creating an image which could be started in the cluster claimed by prow and is hosting the eval-tests and everything needed to run them. Also patching the template, because with postgres it does not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic command-line argument configuration in the evaluation script.
  * Introduced a new Docker container image for evaluation workflows.
  * Added an automated entrypoint script for streamlined evaluation execution.
  * Provided an OpenShift template to deploy and expose the evaluation service with configurable parameters.

* **Chores**
  * Updated configuration to use SQLite instead of PostgreSQL for local data storage, simplifying setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->