### PR TITLE
Use sqlite for metadata store

### DIFF
--- a/config/llama_stack_client_config.yaml
+++ b/config/llama_stack_client_config.yaml
@@ -62,13 +62,8 @@ providers:
     provider_type: remote::model-context-protocol
     config: {}
 metadata_store:
-  type: postgres
-  host: ${env.POSTGRES_HOST:=localhost}
-  port: ${env.POSTGRES_PORT:=5432}
-  db: ${env.POSTGRES_DB:=llamastack}
-  user: ${env.POSTGRES_USER:=llamastack}
-  password: ${env.POSTGRES_PASSWORD:=llamastack}
-  table_name: llamastack_kvstore
+  type: sqlite
+  db_path: ${env.SQLITE_STORE_DIR:=/tmp/.llama/distributions/starter}/registry.db
 inference_store:
   type: postgres
   host: ${env.POSTGRES_HOST:=localhost}


### PR DESCRIPTION
The metadata store remembers things like the MCP endpoint, that may change in the llama-stack config between versions. This is annoying because the config should take precedence. If we change the config, we don't want it to remember the old values.

This is a llama-stack bug that needs to be fixed, and when it does this commit needs to be reverted.

We have no value for storing this stuff in a database for now anyway, so we move it to using a temporary sqlite database that gets thrown away when the pod is updated with a new config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the metadata storage configuration to use a SQLite backend instead of PostgreSQL. The database path is now set via an environment variable with a default option. No changes were made to inference storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->