### PR TITLE
Use sqlite for metadata store

### DIFF
--- a/config/llama_stack_client_config.yaml
+++ b/config/llama_stack_client_config.yaml
@@ -62,13 +62,8 @@ providers:
     provider_type: remote::model-context-protocol
     config: {}
 metadata_store:
-  type: postgres
-  host: ${env.POSTGRES_HOST:=localhost}
-  port: ${env.POSTGRES_PORT:=5432}
-  db: ${env.POSTGRES_DB:=llamastack}
-  user: ${env.POSTGRES_USER:=llamastack}
-  password: ${env.POSTGRES_PASSWORD:=llamastack}
-  table_name: llamastack_kvstore
+  type: sqlite
+  db_path: ${env.SQLITE_STORE_DIR:=/tmp/.llama/distributions/starter}/registry.db
 inference_store:
   type: postgres
   host: ${env.POSTGRES_HOST:=localhost}

--- a/template.yaml
+++ b/template.yaml
@@ -284,13 +284,8 @@ objects:
           provider_type: remote::model-context-protocol
           config: {}
       metadata_store:
-        type: postgres
-        host: ${env.LLAMA_STACK_POSTGRES_HOST}
-        port: ${env.LLAMA_STACK_POSTGRES_PORT}
-        db: ${env.LLAMA_STACK_POSTGRES_NAME}
-        user: ${env.LLAMA_STACK_POSTGRES_USER}
-        password: ${env.LLAMA_STACK_POSTGRES_PASSWORD}
-        table_name: llamastack_kvstore
+        type: sqlite
+        db_path: ${STORAGE_MOUNT_PATH}/sqlite/registry.db
       inference_store:
         type: postgres
         host: ${env.LLAMA_STACK_POSTGRES_HOST}


### PR DESCRIPTION
The metadata store remembers things like the MCP endpoint, that may change in the llama-stack config between versions. This is annoying because the config should take precedence. If we change the config, we don't want it to remember the old values.

This is a llama-stack bug that needs to be fixed, and when it does this commit needs to be reverted.

We have no value for storing this stuff in a database for now anyway, so we move it to using a temporary sqlite database that gets thrown away when the pod is updated with a new config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to use SQLite instead of PostgreSQL for the metadata store.  
  * Simplified environment variables for the metadata store to use a single database path.  
  * No changes to the inference store configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->