### PR TITLE
pin litellm to 1.75.3

### DIFF
--- a/Containerfile.add_llama_to_lightspeed
+++ b/Containerfile.add_llama_to_lightspeed
@@ -13,7 +13,7 @@ RUN cd /app-root/ && python3.12 -m pip install .
 
 RUN python3.12 -m pip install pyyaml pyaml
 
-RUN python3.12 -m pip install litellm[proxy]
+RUN python3.12 -m pip install litellm[proxy]==1.75.3
 
 RUN python3.12 -m pip install sqlalchemy
 

--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -4,7 +4,7 @@ FROM quay.io/lightspeed-core/lightspeed-stack@sha256:81918785ab98d8c2934855cbce6
 
 RUN python3 -m ensurepip --default-pip && pip install --upgrade pip
 
-RUN python3 -m pip install pyyaml pyaml litellm[proxy] sqlalchemy mcp psycopg2-binary
+RUN python3 -m pip install pyyaml pyaml litellm[proxy]==1.75.3 sqlalchemy mcp psycopg2-binary
 
 USER 1001
 


### PR DESCRIPTION
follow up on #106

related to https://github.com/lightspeed-core/lightspeed-stack/pull/370

a workaround for https://github.com/BerriAI/litellm/pull/13447 (workaround for https://github.com/meta-llama/llama-stack/issues/3072)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation process to use a specific version of the litellm[proxy] Python package for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->