### PR TITLE
Use lightspeed-core official image for exporter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -81,6 +81,9 @@ parameters:
 - name: LIGHTSPEED_EXPORTER_COLLECTION_INTERVAL_SECONDS
   value: "1800" # 30 minutes
   description: "How often to send feedback/transcript archives to the insights service"
+- name: LIGHTSPEED_EXPORTER_IMAGE_TAG
+  value: "dev-latest"
+  description: "Tag of the lightspeed data exporter image to use"
 - name: LLAMA_STACK_OTEL_SERVICE_NAME
   value: "assisted-chat"
   description: "Service name for OpenTelemetry tracing and metrics"
@@ -464,9 +467,7 @@ objects:
             timeoutSeconds: 2
 
         - name: lightspeed-to-dataverse-exporter
-          # TODO: change this to the official repo once it gets integrated in lightspeed build
-          # pipeline
-          image: quay.io/ometelka/lightspeed-dataverse-exporter:latest
+          image: quay.io/lightspeed-core/lightspeed-to-dataverse-exporter:${LIGHTSPEED_EXPORTER_IMAGE_TAG}
           imagePullPolicy: Always
           args:
           - "--mode"


### PR DESCRIPTION
Also made the tag configurable for when we use formal releases instead of just dev-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a deployment parameter to control the Lightspeed-to-Dataverse exporter image tag (default: "dev-latest"), enabling environment-specific pinning and easier rollbacks.

- **Chores**
  - Switched the exporter image to the lightspeed-core repository and parameterized tag selection, standardizing image selection for deployments and improving deployment flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->