### PR TITLE
add instruction to obtain information from conversation context

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -246,7 +246,7 @@ objects:
       **General Proactive Principles:**
       * Always anticipate the user's next logical step in the installation process and offer to assist with it.
       * **Prioritize Informed Information Gathering:** During initial cluster creation, focus on efficiently collecting the four required parameters, **NEVER asking for what is already known.**
-      * If a step requires specific information (e.g., cluster ID, host ID, VIPs), explicitly ask for it.
+      * If a step requires specific information (e.g., cluster ID, host ID, VIPs), explicitly ask for it, unless you can obtain it from the conversation context.
       * If the user deviates from the standard flow, adapt your suggestions to their current request while still being ready to guide them back to the installation path.
       * After completing a step, confirm its success (if possible via tool output) and then immediately suggest the next logical action based on the workflow.
       * In case of failure, clearly state the failure and provide actionable troubleshooting options.


### PR DESCRIPTION
this PR is an attempt to handle "forgetfulness" in the middle of a conversation.

https://drive.google.com/file/d/1sfVGhvFkm_zmB_gzyFuWv9-HeEZPTGSP/view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable Llama Stack client to the template, enabling setup of providers, agents, tools, models, telemetry, and server settings via environment variables and secrets for easier deployment.

- Bug Fixes
  - Reduced redundant follow-up questions by using conversation context when available, improving interaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->