### PR TITLE
eval: data model change for multi-eval

### DIFF
--- a/test/evals/eval.py
+++ b/test/evals/eval.py
@@ -21,55 +21,60 @@ logging.getLogger("lsc_agent_eval").setLevel(logging.INFO)
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Agent goal evaluation")
-    
+
     parser.add_argument(
         "--eval_data_yaml",
         default="eval_data.yaml",
-        help="Path to evaluation data YAML file (default: eval_data.yaml)"
+        help="Path to evaluation data YAML file (default: eval_data.yaml)",
     )
-    
+
     parser.add_argument(
         "--agent_endpoint",
         default="http://localhost:8090",
-        help="Agent endpoint URL (default: http://localhost:8090)"
+        help="Agent endpoint URL (default: http://localhost:8090)",
     )
-    
+
     parser.add_argument(
-        "--agent_provider",
-        default="gemini",
-        help="Agent provider (default: gemini)"
+        "--endpoint_type",
+        choices=["streaming", "query"],
+        default="streaming",
+        help="Endpoint type to use for agent queries (default: streaming)",
     )
-    
+
+    parser.add_argument(
+        "--agent_provider", default="gemini", help="Agent provider (default: gemini)"
+    )
+
     parser.add_argument(
         "--agent_model",
         default="gemini/gemini-2.5-flash",
-        help="Agent model (default: gemini/gemini-2.5-flash)"
+        help="Agent model (default: gemini/gemini-2.5-flash)",
     )
-    
+
     parser.add_argument(
         "--judge_provider",
         default="gemini",
-        help="Judge provider for LLM evaluation (default: gemini)"
+        help="Judge provider for LLM evaluation (default: gemini)",
     )
-    
+
     parser.add_argument(
         "--judge_model",
         default="gemini-2.5-flash",
-        help="Judge model for LLM evaluation (default: gemini-2.5-flash)"
+        help="Judge model for LLM evaluation (default: gemini-2.5-flash)",
     )
-    
+
     parser.add_argument(
         "--agent_auth_token_file",
         default="ocm_token.txt",
-        help="Path to agent auth token file (default: ocm_token.txt)"
+        help="Path to agent auth token file (default: ocm_token.txt)",
     )
-    
+
     parser.add_argument(
         "--result_dir",
         default="eval_output",
-        help="Directory for evaluation results (default: eval_output)"
+        help="Directory for evaluation results (default: eval_output)",
     )
-    
+
     return parser.parse_args()
 
 

--- a/test/evals/eval_data.yaml
+++ b/test/evals/eval_data.yaml
@@ -2,40 +2,40 @@
   conversation:
     - eval_id: basic_introduction
       eval_query: Hi!
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "Hello! I'm the Assisted Installer, your guide for OpenShift cluster installation. How can I help you today?"
 
 - conversation_group: basic_cluster_request_conv
   conversation:
     - eval_id: basic_cluster_request
       eval_query: I want to install an OCP cluster
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "Great, I can help you with that. To create a cluster, I'll need some information from you. First, what would you like to call your cluster? And what base domain would you like to use? And finally, what OpenShift version would you like to install?"
 
 - conversation_group: list_versions_conv
   conversation:
     - eval_id: list_versions
       eval_query: List the available OpenShift versions
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "There are several versions of OpenShift available. The most recent production version is 4.19, 4.20 pre release versions are available as well as several previous versions."
 
 - conversation_group: available_operators_conv
   conversation:
     - eval_id: available_operators
       eval_query: What operators are available?
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "The operators that can be installed onto clusters are OpenShift AI and OpenShift Virtualization."
 
 - conversation_group: sno_requirements_conv
   conversation:
     - eval_id: sno_requirements
       eval_query: What are the host requirements for a single node cluster?
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "A single node cluster requires 8 CPU cores 16 GB of RAM and 100 GB of storage"
 
 - conversation_group: multinode_requirements_conv
   conversation:
     - eval_id: multinode_requirements
       eval_query: What are the host requirements for a multinode cluster?
-      eval_type: judge-llm
+      eval_types: [response_eval:accuracy]
       expected_response: "Control plane nodes in a multi-node cluster require 4 CPU cores 16 GB of RAM and 100 GB of storage, the compute nodes in this cluster require 2 CPU cores, 8 GB of RAM and 100GB of storage"


### PR DESCRIPTION
Modified data model/arguments required for multi-eval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to choose the evaluation endpoint type (streaming or query), defaulting to streaming, while keeping a separate option for specifying the agent provider.

* **Tests**
  * Updated several evaluation configurations to use a standardized list-based eval_types format (e.g., response_eval:accuracy) for multiple conversation test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->