### PR TITLE
add ServiceAccount to openshift template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -365,6 +365,15 @@ objects:
       server:
         port: ${LLAMA_STACK_SERVER_PORT}
 
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: assisted-chat
+    labels:
+      app: assisted-chat
+  imagePullSecrets:
+  - name: quay.io
+
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -381,6 +390,7 @@ objects:
         labels:
           app: assisted-chat
       spec:
+        serviceAccountName: assisted-chat
         containers:
         - name: lightspeed-stack
           image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21020

adding a ServiceAccount to avoid using `default` and also using a pull secret for auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a dedicated service account with an image pull secret to enable pulling container images from the private registry.
  * Updated the deployment to use the new service account, improving reliability of image pulls and reducing deployment failures.
  * Enhanced operational security by scoping registry access through the service account.
  * No user-facing UI changes; deployment behavior is more stable and consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->