### PR TITLE
Add Makefile targets to query different environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: all \
 	build-images \
 	build-inspector build-assisted-mcp build-lightspeed-stack build-lightspeed-plus-llama-stack build-ui \
-	generate run resume stop rm logs query query-interactive mcphost test-eval psql sqlite help
+	generate run resume stop rm logs query query-int query-stage query-interactive mcphost test-eval psql sqlite help
 
 all: help ## Show help information
 
@@ -56,9 +56,17 @@ logs: ## Show logs for the assisted-chat services
 	@echo "Showing logs for assisted-chat services..."
 	./scripts/logs.sh
 
-query: ## Query the assisted-chat services
-	@echo "Querying assisted-chat services..."
+query: ## Query the assisted-chat services (localhost)
+	@echo "Querying assisted-chat services (localhost)..."
 	./scripts/query.sh
+
+query-int: ## Query the assisted-chat services (integration environment)
+	@echo "Querying assisted-chat services (integration environment)..."
+	QUERY_ENV=int ./scripts/query.sh
+
+query-stage: ## Query the assisted-chat services (stage environment)
+	@echo "Querying assisted-chat services (stage environment)..."
+	QUERY_ENV=stage ./scripts/query.sh
 
 query-interactive: query ## Query the assisted-chat services (deprecated, use 'query')
 	@echo "WARNING: 'query-interactive' is deprecated. Use 'make query' instead."
@@ -92,5 +100,7 @@ help: ## Show this help message
 	@echo "  make run"
 	@echo "  make logs"
 	@echo "  make query"
+	@echo "  make query-int"
+	@echo "  make query-stage"
 	@echo "  make query-interactive"
 	@echo "  make test-eval"

--- a/scripts/query.sh
+++ b/scripts/query.sh
@@ -13,8 +13,21 @@ PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
 # Source the OCM token utility
 source "$PROJECT_ROOT/utils/ocm-token.sh"
 
+# Configure base URL based on QUERY_ENV environment variable
+case "${QUERY_ENV:-}" in
+    "int")
+        BASE_URL="https://assisted-chat.api.integration.openshift.com"
+        ;;
+    "stage")
+        BASE_URL="https://assisted-chat.api.stage.openshift.com"
+        ;;
+    *)
+        BASE_URL="http://localhost:8090"
+        ;;
+esac
+
 get_available_models() {
-    curl --silent --show-error -X 'GET' 'http://0.0.0.0:8090/v1/models' -H 'accept: application/json'
+    curl --silent --show-error -X 'GET' "${BASE_URL}/v1/models" -H 'accept: application/json'
 }
 
 select_model() {
@@ -61,7 +74,7 @@ get_conversation_history() {
     tmpfile=$(mktemp)
     status=$(curl --silent --show-error --output "$tmpfile" --write-out "%{http_code}" \
         -H "Authorization: Bearer ${OCM_TOKEN}" \
-        "http://localhost:8090/v1/conversations/${conversation_id}")
+        "${BASE_URL}/v1/conversations/${conversation_id}")
     body=$(cat "$tmpfile")
     rm "$tmpfile"
 
@@ -137,7 +150,7 @@ select_conversation() {
     tmpfile=$(mktemp)
     status=$(curl --silent --show-error --output "$tmpfile" --write-out "%{http_code}" \
         -H "Authorization: Bearer ${OCM_TOKEN}" \
-        'http://localhost:8090/v1/conversations')
+        "${BASE_URL}/v1/conversations")
     body=$(cat "$tmpfile")
     rm "$tmpfile"
 
@@ -243,7 +256,7 @@ send_curl_query() {
 
     status=$(curl --silent --show-error --output "$tmpfile" --write-out "%{http_code}" \
         -H "Authorization: Bearer ${OCM_TOKEN}" \
-        'http://localhost:8090/v1/query' \
+        "${BASE_URL}/v1/query" \
         --json "$json_payload")
     body=$(cat "$tmpfile")
     rm "$tmpfile"


### PR DESCRIPTION
Allows us to quickly try out the assisted-chat services in different environments (for now just integration and staging) with the query script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to query integration and stage environments.
  * Query tool now selects the service endpoint based on the chosen environment (integration, stage, or localhost).

* **Documentation**
  * Updated help output to list the new commands and clarified that the default query targets localhost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->