### PR TITLE
Prod Auth for Lightspeed Exporter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -73,7 +73,12 @@ parameters:
   description: "The full URL to use when uploading feedback/transcript archives to the insights ingress service"
 - name: INSIGHTS_INGRESS_SECRET_NAME
   value: "insights-ingress"
-  description: "The name of a secret containing the auth_token for the insights ingress server"
+  description: |
+    The name of a secret containing the auth_token for the insights ingress server. Will be ignored
+    if it doesn't exist but LIGHTSPEED_EXPORTER_AUTH_MODE should be set to 'sso' in that case.
+- name: SSO_CLIENT_SECRET_NAME
+  value: "ingress-sso"
+  description: "Name of the K8s secret that contains the SSO client credentials"
 - name: INSIGHTS_SERVICE_ID
   value: "ocm-assisted-chat"
   description: "The service id used when exporting feedback/transcripts data to the insights ingress server"
@@ -83,6 +88,14 @@ parameters:
 - name: LIGHTSPEED_EXPORTER_IMAGE_TAG
   value: "dev-latest"
   description: "Tag of the lightspeed data exporter image to use"
+- name: LIGHTSPEED_EXPORTER_AUTH_MODE
+  value: "sso"
+  description: |
+    The type of authentication to use for the lightspeed data exporter to access the api ingress
+    server. Valid values are 'manual' 'sso' (sso.redhat.com auth) and 'openshift' (k8s pull secret).
+    If 'manual' is specified the INSIGHTS_INGRESS_SECRET_NAME secret should contain a valid auth
+    token in the data item `auth_token`. For 'sso', the SSO_CLIENT_SECRET_NAME secret should contain
+    the credentials for a valid SSO service account.
 - name: LLAMA_STACK_OTEL_SERVICE_NAME
   value: "assisted-chat"
   description: "Service name for OpenTelemetry tracing and metrics"
@@ -487,17 +500,30 @@ objects:
           imagePullPolicy: Always
           args:
           - "--mode"
-          - "manual"
+          - "${LIGHTSPEED_EXPORTER_AUTH_MODE}"
           - "--config"
           - "/etc/config/config.yaml"
           - "--log-level"
           - "INFO"
           env:
+          - name: CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${SSO_CLIENT_SECRET_NAME}
+                key: client_id
+                optional: true
+          - name: CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: ${SSO_CLIENT_SECRET_NAME}
+                key: client_secret
+                optional: true
           - name: INGRESS_SERVER_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
                 name: ${INSIGHTS_INGRESS_SECRET_NAME}
                 key: auth_token
+                optional: true
           resources:
             limits:
               memory: "512Mi"


### PR DESCRIPTION
This uses sso auth in prod and makes the manual auth secret optional so
we don't have to have it in prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable authentication mode for the Lightspeed data exporter via a new parameter (default: "sso"). Supports "manual", "sso", and "openshift" modes.
  * Added a parameter to name the SSO client secret.

* **Improvements**
  * Exporter mode is driven by configuration instead of being hard-coded.
  * Deployment is more resilient: auth token and SSO client credentials are now optional based on the chosen mode.

* **Documentation**
  * Updated parameter descriptions to explain valid modes and secret requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->