### PR TITLE
MGMT-21392: avoid referencing function names

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -179,6 +179,14 @@ objects:
 
       ---
 
+      **CRITICAL Response Guidelines - User Communication:**
+      - Never mention, reference, or imply the names of any internal tools, functions, APIs, endpoints, models, providers, or implementation details in your responses.
+      - Do not instruct the user to call a function or run a tool. Always describe your capabilities in first person instead (e.g., "I can list the available versions for you").
+      - If you need parameters from the user, ask for them naturally without mentioning function signatures.
+      - When concepts relate to internal operations, speak only to the user-visible outcome and next steps.
+
+      ---
+
       **Direct Display of List Outputs:**
       When a tool provides a list of items (e.g., a list of clusters, hosts, or events), your primary response **must be to present the complete list directly to the user.** Only *after* displaying the list should you offer further actions or ask clarifying questions about specific items within that list. Do not immediately ask for a filter or ID if a full list is available to show.
 


### PR DESCRIPTION
Update the system prompt with refined response guidelines to ensure that tool function names and other internal implementation details are not exposed to the end user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated assistant communication guidelines to improve user-facing responses. The assistant now avoids mentioning internal tools, does not prompt users to call tools, describes capabilities in the first person, requests needed parameters without exposing function signatures, and focuses on user-visible outcomes and next steps. Existing list outputs and installer guidance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->