### PR TITLE
MGMT-21408 Vertex assisted-chat dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.env
 /config/lightspeed-stack.yaml
 /config/systemprompt.txt
+/config/vertex-credentials.json
 .vscode
 ocm_token.txt
 .venv

--- a/README.md
+++ b/README.md
@@ -5,19 +5,23 @@ This repo builds the images for and runs in a podman pod the following services:
 - [x] lightspeed-core + llama-stack (Same container, built separately)
 - [x] assisted UI
 - [x] inspector
+- [x] postgres
 
 # Pre-requisites
 
-- **Red Hat Developer Subscription** (required for building container images)
+- the `ocm` command (get it [here](https://console.redhat.com/openshift/token))
+
+- Either Vertex AI service account credentials or a Gemini API key. If using a Gemini API key, run `make generate` for instructions on how to get one.
+
+- An OpenShift pull-secret (https://cloud.redhat.com/openshift/install/pull-secret)
+    - Apply it to podman by copying it to ~/.config/containers/auth.json
+
+- Some report needing a **Red Hat Developer Subscription** (required for building container images)
+  - You might not need one
   - Sign up for free at https://developers.redhat.com/register
-  - **Both steps are required:**
     1. Login to container registry: `podman login registry.access.redhat.com`
     2. Register your system: `sudo subscription-manager register --username <your-username>`
   - Verify registration: `subscription-manager status`
-- the `ocm` command (get it [here](https://console.redhat.com/openshift/token))
-- Gemini API key (you will be prompted with instructions)
-- An OpenShift pull-secret (https://cloud.redhat.com/openshift/install/pull-secret)
-    - Apply it to podman by copying it to ~/.config/containers/auth.json
 
 ## Dependencies
 
@@ -32,10 +36,50 @@ git submodule init
 git submodule update
 ```
 
+# Overview
 
-# Usage
+## Basics
 
-`make help`
+This repo uses a podman pod to run all the required services for the Assisted
+chat bot. The pod is defined in `assisted-chat-pod.yaml`. The pod images are
+built from the git submodules in this repo. We use a Makefile for running
+commands.
+
+You are expected to first run `make generate` to generate the `.env` and
+configuration files. `make generate` is interactive and will ask you whether
+you want to use a Gemini API key or Vertex AI service account credentials. 
+
+Before running the pod, you should run `make build-images` to build all the
+required images. You can also build individual images using `make build-*`
+commands (see `make help`).
+
+Once you've generated the configuration files and built the images, you can run
+the pod with `make run`. This will start the pod and follow its logs. You can
+safely ctrl+c out of it and the pod will continue running in the background. To
+stop the pod, run `make stop` and optionally `make rm` to remove it completely.
+If you wish to see the logs again while it's running, use `make logs`.
+
+To interact with assisted-chat, use `make query`. 
+
+## Extra
+
+You can also use `make query-int` and `make query-stage` to interact with the
+SaaS deployed integration and staging environments, respectively. This does not
+require the pod to be running.
+
+You can interact with the model directly with `mcphost` through `make mcphost`
+- it's a bit weird, you have to first Ctrl+C out of it, then quickly run `make
+mcphost` again for it to actually work. Please fix it if you figure out why
+it's happening.
+
+To see the contents of the postgres database, use `make psql`. This will put
+you in a `psql` shell. The database is used by both llama-stack and
+lightspeed-stack. llama-stack uses the `default` schema while lightspeed-stack
+uses the `lightspeed-stack` schema. The `psql` shell is pre-configured to see
+both schemas. If you're running `lightspeed-stack` without a database
+configuration you can use `make sqlite` to browse the contents of the temporary
+SQLite database.
+
 
 ## Override
 

--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -9,6 +9,8 @@ spec:
       env:
         - name: GEMINI_API_KEY
           value: ${GEMINI_API_KEY}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /tmp/vertex-credentials.json
         - name: ASSISTED_CHAT_POSTGRES_HOST
           value: localhost
         - name: ASSISTED_CHAT_POSTGRES_PORT
@@ -32,6 +34,10 @@ spec:
         - mountPath: /tmp/systemprompt.txt
           name: config
           subPath: systemprompt.txt
+        - mountPath: /tmp/vertex-credentials.json
+          name: config
+          subPath: vertex-credentials.json
+          readOnly: true
     - name: assisted-service-mcp
       image: localhost/local-ai-chat-assisted-service-mcp:latest
       env:

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -12,9 +12,42 @@ if [[ ! -f "$PROJECT_ROOT/.env" ]]; then
     echo "Would you like help creating the .env file interactively? (y/n)"
     read -r answer
     if [[ "$answer" == "y" || "$answer" == "Y" ]]; then
-        echo 'Visit https://console.cloud.google.com/apis/credentials?authuser=1&inv=1&invt=Ab1Pvg&project=assisted-installer and log-in if needed. Then press "use API tokens to authenticate" and paste your token here'
-        read -r GEMINI_API_KEY
-        echo "GEMINI_API_KEY=$GEMINI_API_KEY" >"$PROJECT_ROOT/.env"
+        echo 'Would you like to use a Gemini API key or Vertex AI service account? (g/v)'
+        read -r auth_type
+        if [[ "$auth_type" == "g" || "$auth_type" == "G" ]]; then
+            echo 'Visit https://console.cloud.google.com/apis/credentials?authuser=1&inv=1&invt=Ab1Pvg&project=assisted-installer and log-in if needed. Then press "use API tokens to authenticate" and paste your token here'
+            read -sr GEMINI_API_KEY
+            echo "GEMINI_API_KEY=$GEMINI_API_KEY" >"$PROJECT_ROOT/.env"
+            chmod 600 "$PROJECT_ROOT/.env"
+        elif [[ "$auth_type" == "v" || "$auth_type" == "V" ]]; then
+            echo 'Please enter the path to your Vertex AI service account credentials file:'
+            read -r VERTEX_AI_SERVICE_ACCOUNT_CREDENTIALS_PATH
+            if [[ ! -f "$VERTEX_AI_SERVICE_ACCOUNT_CREDENTIALS_PATH" ]]; then
+                echo "File not found: $VERTEX_AI_SERVICE_ACCOUNT_CREDENTIALS_PATH"
+                exit 1
+            fi
+
+            echo "$VERTEX_AI_SERVICE_ACCOUNT_CREDENTIALS_PATH will be copied to $PROJECT_ROOT/config/vertex-credentials.json, do you want to continue? (y/n)"
+            read -r should_copy
+            if [[ "$should_copy" != "y" && "$should_copy" != "Y" ]]; then
+                echo "Exiting."
+                exit 1
+            fi
+
+            cp "$VERTEX_AI_SERVICE_ACCOUNT_CREDENTIALS_PATH" "$PROJECT_ROOT/config/vertex-credentials.json"
+
+            # We must set the GEMINI_API_KEY to a dummy value, as
+            # lightspeed-stack wrongly expects it to be set for all Gemini
+            # providers, even if we are using Vertex AI service account
+            # authentication.
+            echo GEMINI_API_KEY="dummy" >"$PROJECT_ROOT/.env"
+            chmod 600 "$PROJECT_ROOT/.env"
+
+            echo "Your Gemini API key will be set to a dummy value, as it is not needed for Vertex AI service account authentication, if you want to be able to use both, modify .env manually."
+        else
+            echo "Invalid choice. Exiting."
+            exit 1
+        fi
     else
         echo "Exiting. You can copy .env.template to .env and fill it in manually."
         exit 1
@@ -26,17 +59,14 @@ source "$PROJECT_ROOT/.env"
 mkdir -p "$PROJECT_ROOT/config"
 
 if [[ -f $OVERRIDE_FILE ]]; then
-  OVERRIDE_PARAMS="--param-file=$OVERRIDE_FILE"
+    OVERRIDE_PARAMS="--param-file=$OVERRIDE_FILE"
 fi
 
-oc process  --local \
-  -f $PROJECT_ROOT/template.yaml \
-  ${OVERRIDE_PARAMS-} \
-  --param-file=$PROJECT_ROOT/template-params.dev.env | \
-  yq '.items[] | select(.kind == "ConfigMap" and .metadata.name == "lightspeed-stack-config").data."lightspeed-stack.yaml"' -r \
-  > $PROJECT_ROOT/config/lightspeed-stack.yaml
+oc process --local \
+    -f "$PROJECT_ROOT/template.yaml" \
+    "${OVERRIDE_PARAMS-}" \
+    --param-file="$PROJECT_ROOT/template-params.dev.env" |
+    yq '.items[] | select(.kind == "ConfigMap" and .metadata.name == "lightspeed-stack-config").data."lightspeed-stack.yaml"' -r \
+        >"$PROJECT_ROOT/config/lightspeed-stack.yaml"
 
-yq -r '.objects[] | select(.metadata.name == "lightspeed-stack-config") | .data.system_prompt' "$PROJECT_ROOT/template.yaml" > "$PROJECT_ROOT/config/systemprompt.txt"
-
-
-
+yq -r '.objects[] | select(.metadata.name == "lightspeed-stack-config") | .data.system_prompt' "$PROJECT_ROOT/template.yaml" >"$PROJECT_ROOT/config/systemprompt.txt"

--- a/scripts/query.sh
+++ b/scripts/query.sh
@@ -41,12 +41,12 @@ select_model() {
 
         # Extract relevant fields
         | . as $model
-        | $model.identifier as $model_name
+        | $model.provider_resource_id as $model_name
         | $model.provider_id as $provider
 
         # Determine type label based on model identifier
-        | (if ($model_name | startswith("gemini/gemini/")) then "Vertex AI"
-           elif ($model_name | contains("gemini")) then "True Gemini"
+        | (if ($model_name | startswith("gemini/")) then "Gemini"
+           elif ($model_name) then "Vertex Gemini"
            else ""
            end) as $type_label
 


### PR DESCRIPTION
A few tweaks to the generate script, query script and pod config to properly support Vertex AI usage with service account authentication rather than Gemini API keys.

Also improved README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive setup now offers choosing a Gemini API key or a Vertex AI service account, with prompts, validation, and optional credential copy.

* **Refactor**
  * Model listing and labels updated to use provider IDs and clearer "Gemini" vs "Vertex Gemini" distinctions.

* **Documentation**
  * README expanded with Postgres service, setup/workflow steps, usage commands (generate, build, run, psql, query), prerequisites, and overrides.

* **Chores**
  * Local Vertex credentials ignored from version control; runtime can consume provided credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->