### PR TITLE
MGMT-21239: moving the deploy script of assisted-chat to the repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ build-ui: ## Build UI image
 	@echo "Building UI image..."
 	./scripts/build-images.sh ui
 
+.PHONY:
+deploy-template:
+	scripts/deploy_template.sh
+
 generate: ## Generate configuration files
 	@echo "Generating configuration files..."
 	./scripts/generate.sh

--- a/scripts/deploy_template.sh
+++ b/scripts/deploy_template.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+#All the secret are expected to be mounted under /var/run/secrets by the ci-operator
+
+#$ASSISTED_CHAT_IMG is not in repo/image:tag format but rather in repo/<image name>@sha256:<digest>
+#The template needs the tag, and it references the image by <image name>:<tag> so splitting the variable by ":" works for now
+
+echo $ASSISTED_CHAT_IMG
+IMAGE=$(echo $ASSISTED_CHAT_IMG | cut -d ":" -f1)
+TAG=$(echo $ASSISTED_CHAT_IMG | cut -d ":" -f2)
+
+oc create secret generic -n $NAMESPACE gemini-api-key --from-file=api_key=/var/run/secrets/gemini/api_key
+oc create secret generic -n $NAMESPACE llama-stack-db --from-file=db.ca_cert=/var/run/secrets/llama-stack-db/db.ca_cert \
+                                                      --from-file=db.host=/var/run/secrets/llama-stack-db/db.host \
+                                                      --from-file=db.name=/var/run/secrets/llama-stack-db/db.name \
+                                                      --from-file=db.password=/var/run/secrets/llama-stack-db/db.password \
+                                                      --from-file=db.port=/var/run/secrets/llama-stack-db/db.port \
+                                                      --from-file=db.user=/var/run/secrets/llama-stack-db/db.user
+
+patch template.yaml -i test/prow/template_patch.diff
+echo "GEMINI_API_KEY=$(cat /var/run/secrets/gemini/api_key)" > .env
+make generate
+sed -i 's/user_id_claim: sub/user_id_claim: client_id/g' config/lightspeed-stack.yaml
+sed -i 's/username_claim: preferred_username/username_claim: clientHost/g' config/lightspeed-stack.yaml
+
+oc process -p IMAGE=$IMAGE -p IMAGE_TAG=$TAG -p GEMINI_API_SECRET_NAME=gemini-api-key -p ASSISTED_CHAT_DB_SECRET_NAME=llama-stack-db -f template.yaml --local | oc apply -n $NAMESPACE -f -
+
+
+sleep 5
+POD_NAME=$(oc get pods -n $NAMESPACE | tr -s ' ' | cut -d ' ' -f1| grep assisted-chat)
+oc wait --for=condition=Ready pod/$POD_NAME --timeout=300s

--- a/test/prow/Dockerfile
+++ b/test/prow/Dockerfile
@@ -2,10 +2,9 @@ FROM registry.access.redhat.com/ubi9/python-311:latest
 
 USER 0
 RUN yum install -y jq patch
+RUN pip install yq
 RUN pip install git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
 RUN mkdir -p /opt/app-root/src
 WORKDIR /opt/app-root/src
 COPY . .
 RUN chmod 755 test/prow/entrypoint.sh
-
-ENTRYPOINT [ "/opt/app-root/src/test/prow/entrypoint.sh" ]

--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -15,4 +15,4 @@ echo $OCM_TOKEN > test/evals/ocm_token.txt
 
 cd test/evals
 
-python eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}"
+#python eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}"

--- a/test/prow/template.yaml
+++ b/test/prow/template.yaml
@@ -21,6 +21,7 @@ objects:
         containers:
         - name: assisted-chat-eval-test
           image: ${IMAGE_NAME}
+          command: [ "/opt/app-root/src/test/prow/entrypoint.sh" ]
           imagePullPolicy: Always
           env:
           - name: CLIENT_ID


### PR DESCRIPTION
[MGMT-21239](https://issues.redhat.com//browse/MGMT-21239): moving the deploy script of assisted-chat to the repository. This way it would be easier to modify the deployment flow of the assisted chat pod.
Also removing the entrypoint from the test/prow/Dockerfile so the image would be reusable in the CI. The entrypoint can be defined in the openshift template too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deploy-template command to streamline environment setup and deployment.
* **Chores**
  * Introduced an automated deployment script that provisions secrets, patches templates, updates config values, and applies manifests while waiting for readiness.
* **Tests**
  * Adjusted the test container image to include YAML tooling and removed the automatic entrypoint.
  * Disabled a previously executed evaluation step in the test startup script.
  * Updated the test deployment template to explicitly run the provided entrypoint script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->