### PR TITLE
THIS IS A TEST COMMIT, DO NOT MERGE

### DIFF
--- a/scripts/deploy_template.sh
+++ b/scripts/deploy_template.sh
@@ -9,6 +9,7 @@ set -o pipefail
 #$ASSISTED_CHAT_IMG is not in repo/image:tag format but rather in repo/<image name>@sha256:<digest>
 #The template needs the tag, and it references the image by <image name>:<tag> so splitting the variable by ":" works for now
 
+echo "THIS IS A TEST COMMIT, DO NOT MERGE"
 echo $ASSISTED_CHAT_IMG
 IMAGE=$(echo $ASSISTED_CHAT_IMG | cut -d ":" -f1)
 TAG=$(echo $ASSISTED_CHAT_IMG | cut -d ":" -f2)


### PR DESCRIPTION
THIS IS A TEST COMMIT, DO NOT MERGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment template script to print a temporary notice (“THIS IS A TEST COMMIT, DO NOT MERGE”) before processing image/tag values. This adds one extra log line in deployment/CI output only and does not affect behavior, logic, or error handling. No user-facing changes or functionality impacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->