### PR TITLE
enable SSL and CA cert for lightspeed-stack

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -178,6 +178,8 @@ objects:
           db: ${env.ASSISTED_CHAT_POSTGRES_NAME}
           user: ${env.ASSISTED_CHAT_POSTGRES_USER}
           password: ${env.ASSISTED_CHAT_POSTGRES_PASSWORD}
+          ssl_mode: "verify-full"
+          ca_cert_path: /etc/tls/ca-bundle.pem
           namespace: lightspeed-stack
     system_prompt: |
       You are OpenShift Lightspeed Intelligent Assistant - an intelligent virtual assistant and expert on all things related to OpenShift installation, configuration, and troubleshooting, specifically with the Assisted Installer.


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21487

this PR enables secure connectivity between the service and the database for the lightspeed-stack persistence layer.

we mount a DB CA certificate to a file on the pod and pass that file through the lightspeed-stack configuration, as was implemented in https://github.com/lightspeed-core/lightspeed-stack/pull/347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled full TLS verification for Postgres connections.
  * Switched CA certificate provisioning from environment variable to a mounted secret.
  * Updated container to read the CA certificate from the mounted location and removed legacy env-based config.
  * Improves connection security and aligns with secret management best practices.
  * No user-facing functional changes; ensure the required secret containing the CA certificate is available during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->