### PR TITLE
enable ssl and CA in llama-stack

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -314,6 +314,8 @@ objects:
               db: ${env.ASSISTED_CHAT_POSTGRES_NAME}
               user: ${env.ASSISTED_CHAT_POSTGRES_USER}
               password: ${env.ASSISTED_CHAT_POSTGRES_PASSWORD}
+              ssl_mode: "verify-full"
+              ca_cert_path: /etc/tls/ca-bundle.pem
             responses_store:
               type: postgres
               host: ${env.ASSISTED_CHAT_POSTGRES_HOST}
@@ -321,6 +323,8 @@ objects:
               db: ${env.ASSISTED_CHAT_POSTGRES_NAME}
               user: ${env.ASSISTED_CHAT_POSTGRES_USER}
               password: ${env.ASSISTED_CHAT_POSTGRES_PASSWORD}
+              ssl_mode: "verify-full"
+              ca_cert_path: /etc/tls/ca-bundle.pem
         telemetry:
         - provider_id: meta-reference
           provider_type: inline::meta-reference
@@ -354,6 +358,8 @@ objects:
         db: ${env.ASSISTED_CHAT_POSTGRES_NAME}
         user: ${env.ASSISTED_CHAT_POSTGRES_USER}
         password: ${env.ASSISTED_CHAT_POSTGRES_PASSWORD}
+        ssl_mode: "verify-full"
+        ca_cert_path: /etc/tls/ca-bundle.pem
       models:
       - metadata: {}
         model_id: ${LLAMA_STACK_2_0_FLASH_MODEL}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21487

this PR enables secure connectivity between the service and the database for the llama-stack persistence layer.

we mount a DB CA certificate to a file on the pod and pass that file through the llama-stack configuration, as was implemented in https://github.com/llamastack/llama-stack/pull/3182

related to #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Enabled TLS verification (verify-full) with a configured CA bundle for PostgreSQL connections across the stack, improving data-in-transit security and reliability.
  * Updated internal llama-stack dependency to a newer revision (no user-visible changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->