### PR TITLE
Apply llama-stack and lightspeed-stack `pool_pre_ping` patches

### DIFF
--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -7,6 +7,12 @@ RUN python3 -m ensurepip --default-pip && pip install --upgrade pip
 COPY requirements.txt .
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
+
+USER root
+RUN microdnf install -y patch
+RUN curl -L https://github.com/meta-llama/llama-stack/commit/49c34dd0d49a960fec23d0be854890f219d917e7.patch | patch -p1 -d $(dirname $(dirname $(python3 -c "import llama_stack; print(llama_stack.__file__)")))
+RUN curl -L https://github.com/lightspeed-core/lightspeed-stack/commit/c59ea53ccfe1c6e0fb53d3ac880f925d1d3ede68.patch | patch -p1 -d $(dirname $(dirname $(python3 -c "import lightspeed_stack; print(lightspeed_stack.__file__)")))
+
 USER 1001
 
 EXPOSE 8080


### PR DESCRIPTION
We want to try out https://github.com/llamastack/llama-stack/pull/3208 and https://github.com/lightspeed-core/lightspeed-stack/pull/426 before they merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched underlying Python dependencies within the container to improve reliability and compatibility of the application at runtime.

* **Chores**
  * Updated the container build process to automatically apply dependency patches during image creation while preserving the expected runtime user context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->