### PR TITLE
Restore `ligthspeed-to-dataverse-exporter`

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -482,6 +482,36 @@ objects:
             periodSeconds: 10
             timeoutSeconds: 2
 
+        - name: lightspeed-to-dataverse-exporter
+          image: quay.io/lightspeed-core/lightspeed-to-dataverse-exporter:${LIGHTSPEED_EXPORTER_IMAGE_TAG}
+          imagePullPolicy: Always
+          args:
+          - "--mode"
+          - "manual"
+          - "--config"
+          - "/etc/config/config.yaml"
+          - "--log-level"
+          - "INFO"
+          env:
+          - name: INGRESS_SERVER_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${INSIGHTS_INGRESS_SECRET_NAME}
+                key: auth_token
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "200m"
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+          volumeMounts:
+            - name: lightspeed-exporter-config
+              mountPath: /etc/config/config.yaml
+              subPath: config.yaml
+            - name: data-storage
+              mountPath: ${STORAGE_MOUNT_PATH}
+
         volumes:
         - name: lightspeed-config
           configMap:


### PR DESCRIPTION
It was accidentally removed in a14100a171d9e7f74b5d318564e058a2b17dc3d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background exporter now collects and sends chat feedback and transcripts to a configured destination on a set interval.
  * Supports configurable timing, connection timeout, and optional cleanup of files after successful send.

* **Chores**
  * Deployment updated to include a dedicated exporter component with defined resource limits and secure token-based connectivity.
  * New configuration options available for data directories, allowed subfolders, and service/identity identifiers (admin-configured).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->