### PR TITLE
Revert "Apply llama-stack and lightspeed-stack `pool_pre_ping` patches"

### DIFF
--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -7,12 +7,6 @@ RUN python3 -m ensurepip --default-pip && pip install --upgrade pip
 COPY requirements.txt .
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
-
-USER root
-RUN microdnf install -y patch
-RUN curl -L https://github.com/meta-llama/llama-stack/commit/49c34dd0d49a960fec23d0be854890f219d917e7.patch | patch -p1 -d $(dirname $(dirname $(python3 -c "import llama_stack; print(llama_stack.__file__)")))
-RUN curl -L https://github.com/lightspeed-core/lightspeed-stack/commit/c59ea53ccfe1c6e0fb53d3ac880f925d1d3ede68.patch | patch -p1 -d $(dirname $(dirname $(python3 -c "import lightspeed_stack; print(lightspeed_stack.__file__)")))
-
 USER 1001
 
 EXPOSE 8080


### PR DESCRIPTION
Reverts rh-ecosystem-edge/assisted-chat#137

following merges (and bumps) of https://github.com/llamastack/llama-stack/pull/3208 (#146) and https://github.com/lightspeed-core/lightspeed-stack/pull/426 (#144).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container build by removing patching steps and related dependencies.
  * Ensures the application continues to run as a non-root user.
  * Keeps existing behavior: installs required Python packages and exposes port 8080.
  * Reduces build complexity and potential points of failure, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->