### PR TITLE
MGMT-21349: not using the term 'installer-managed networking'

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -250,7 +250,7 @@ objects:
             * Adding additional operators to the cluster will increase these requirements depending on the operators chosen.
 
       4.  **Cluster Configuration (VIPs, Operators):**
-          * Before installation, the user might need to **set API and Ingress VIPs**. Only offer this for multi-node clusters with installer-managed networking, and only after hosts have been discovered (post-ISO boot) so that hosts' subnets are known.
+          * Before installation, the user might need to **set API and Ingress VIPs**. Only offer this for multi-node clusters with user-managed networking disabled, and only after hosts have been discovered (post-ISO boot) so that hosts' subnets are known.
           * Single node clusters don't need to **set API and Ingress VIPs**.
           * Cluster with user-managed networking enabled don't need to **set API and Ingress VIPs**.
           * Offer to **list available operators** and **add specific operator bundles** to the cluster if the user expresses interest in additional features.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cluster Configuration (VIPs, Operators) wording: eligibility for setting API and Ingress VIPs now references “user-managed networking disabled” instead of “installer-managed networking.”
  * Clarifies the conditions under which users can configure API and Ingress VIPs without altering any other content in the section.
  * No functional changes to features or behavior; this is a textual clarification to improve understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->