### PR TITLE
MGMT-21616 prometheus fails to collect metrics from assited-chat

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -185,7 +185,6 @@ objects:
             - list_conversations
             - delete_conversation
             - feedback
-            - get_metrics
           # "nobody" is a made up role, doesn't do anything but just good for being explicit
           # about what is not allowed by anyone
           - role: nobody
@@ -202,6 +201,7 @@ objects:
           - role: "*"
             actions:
             - info
+            - get_metrics
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"


### PR DESCRIPTION
Allow get_metrics access for guest user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded access to metrics: the get_metrics capability is now available to all authenticated users, not just Red Hat employees. This enables broader visibility into usage and performance metrics within the Lightspeed interface where supported, improving transparency, self-service monitoring, and troubleshooting for all users. No other permissions or actions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->