### PR TITLE
feat(rbac): Update role-based access control rules

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -165,6 +165,57 @@ objects:
           jwt_configuration:
             user_id_claim: ${USER_ID_CLAIM}
             username_claim: ${USERNAME_CLAIM}
+            role_rules:
+              - jsonpath: "$.org_id"
+                operator: "in"
+                value: ["6405426"]
+                roles: ["early_access_user"]
+              - jsonpath: "$.is_internal"
+                operator: "equals"
+                value: "true"
+                roles: ["redhat_employee"]
+      authorization:
+        access_rules:
+          - role: redhat_employee
+            actions:
+            - get_models
+          # Temporarily we only want redhat employees to be able to use the service,
+          # uncomment when we want to allow all authenticated users
+          # - role: "*"
+          #   actions:
+            - query
+            - streaming_query
+            - get_conversation
+            - list_conversations
+            - delete_conversation
+            - feedback
+          - role: early_access_user
+            actions:
+            - get_models
+            - query
+            - streaming_query
+            - get_conversation
+            - list_conversations
+            - delete_conversation
+            - feedback
+
+          # "nobody" is a made up role, doesn't do anything but just good for being explicit
+          # about what is not allowed by anyone
+          - role: nobody
+            actions:
+            # This exposes the database password - once LSC fixes this issue we
+            # can allow this for employees
+            - get_config
+            # For now we don't want to let even administrators / employees access other users conversations
+            - query_other_conversations
+            - delete_other_conversations
+            - list_other_conversations
+            - read_other_conversations
+          # For k8s pod probes
+          - role: "*"
+            actions:
+            - info
+            - get_metrics
       mcp_servers:
         - name: mcp::assisted
           url: "${MCP_SERVER_URL}"


### PR DESCRIPTION
Update the role-based access control (RBAC) configuration in template.yaml to address an authorization issue where tokens from the UI were missing the required redhat:employees role.

The previous configuration used a single role rule that checked for the redhat:employees role within $.realm_access.roles. This change replaces that rule with two new ones:
early_access_user: Assigns this role to users with an org_id of 6405426. redhat_employee: Assigns this role to users where the is_internal claim is true. It also adds the early_access_user role to the list of roles with permissions to interact with the system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced role-based access control with per-role permissions.
  * Added configurable feedback and transcript collection (opt-in/out).
  * Enabled customization of system prompts with an option to disable query-level prompts.
  * Set defaults for model and provider selection.

* **Chores**
  * Added database configuration via environment variables to enhance reliability and scalability.
  * Exposed health and metrics endpoints to support platform probes.
  * Centralized sensitive settings to environment/secret variables for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->