### PR TITLE
set lightspeed authn role_rules to empty list

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -165,19 +165,19 @@ objects:
           jwt_configuration:
             user_id_claim: ${USER_ID_CLAIM}
             username_claim: ${USERNAME_CLAIM}
-            role_rules:
-            - jsonpath: "$.realm_access.roles[*]"
-              operator: "contains"
-              value: "redhat:employees"
-              roles: ["redhat_employee"]
-            - jsonpath: "$.org_id"
-              operator: "in"
-              value: [["6405426"]]
-              roles: ["redhat_employee"]
-            - jsonpath: "$.is_internal"
-              operator: "equals"
-              value: [true]
-              roles: ["redhat_employee"]
+            role_rules: []
+            # - jsonpath: "$.realm_access.roles[*]"
+            #   operator: "contains"
+            #   value: "redhat:employees"
+            #   roles: ["redhat_employee"]
+            # - jsonpath: "$.org_id"
+            #   operator: "in"
+            #   value: [["6405426"]]
+            #   roles: ["redhat_employee"]
+            # - jsonpath: "$.is_internal"
+            #   operator: "equals"
+            #   value: [true]
+            #   roles: ["redhat_employee"]
       authorization:
         access_rules:
           - role: redhat_employee


### PR DESCRIPTION
simply remove the rules to let anyone in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Disabled all JWT role-mapping rules. Dynamic assignment to the employee role is no longer applied.
  * Users previously mapped via realm roles, org ID, or internal flag will not receive the employee role automatically.
  * Authentication and baseline authorization remain intact, but features gated by the employee role may be inaccessible unless granted by other means.

* Documentation
  * Added commented examples of role-mapping rules for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->