### PR TITLE
MGMT-21338: allow disabling query model and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ both schemas. If you're running `lightspeed-stack` without a database
 configuration you can use `make sqlite` to browse the contents of the temporary
 SQLite database.
 
+## Configuration flags
+
+- `DISABLE_QUERY_SYSTEM_PROMPT` (default: `false`): maps to `customization.disable_query_system_prompt` in Lightspeed Stack. When `true`, requests including `system_prompt` are rejected with HTTP 422.
+- `DISABLE_QUERY_MODEL_OVERRIDE` (default: `false`): maps to `customization.disable_query_model_override` in Lightspeed Stack. When `true`, requests including `model` or `provider` are rejected with HTTP 422.
 
 ## Override
 

--- a/template-params.dev.env
+++ b/template-params.dev.env
@@ -4,6 +4,7 @@ LLAMA_CLIENT_CONFIG_PATH=llama_stack_client_config.yaml
 LIGHTSPEED_TRANSCRIPTS_ENABLED=false
 LIGHTSPEED_FEEDBACK_ENABLED=false
 DISABLE_QUERY_SYSTEM_PROMPT=false
+DISABLE_QUERY_MODEL_OVERRIDE=false
 ASSISTED_CHAT_DEFAULT_MODEL=gemini/gemini-2.0-flash
 LIGHTSSPEED_STACK_POSTGRES_SSL_MODE=disable
 AUTHN_ROLE_RULES='[{"jsonpath":"$.realm_access.roles[*]","operator":"contains","value":"redhat:employees","roles":["redhat_employee"]}]'

--- a/template.yaml
+++ b/template.yaml
@@ -120,6 +120,9 @@ parameters:
 - name: DISABLE_QUERY_SYSTEM_PROMPT
   value: "true"
   description: "Corresponds to the lightspeed config customization.disable_query_system_prompt"
+- name: DISABLE_QUERY_MODEL_OVERRIDE
+  value: "false"
+  description: "Corresponds to the lightspeed config customization.disable_query_model_override"
 - name: ASSISTED_CHAT_DEFAULT_MODEL
   value: gemini-2.0-flash
 - name: USER_ID_CLAIM
@@ -188,6 +191,7 @@ objects:
       customization:
         system_prompt_path: "${SYSTEM_PROMPT_PATH}"
         disable_query_system_prompt: ${DISABLE_QUERY_SYSTEM_PROMPT}
+        disable_query_model_override: ${DISABLE_QUERY_MODEL_OVERRIDE}
       inference:
         default_model: ${ASSISTED_CHAT_DEFAULT_MODEL}
         default_provider: gemini


### PR DESCRIPTION
# Summary
Expose and propagate a configuration flag to disable client-side model/provider overrides into Lightspeed Stack, aligning assisted-chat deployment parameters with new validation behavior.

Jira: [MGMT-21338](https://issues.redhat.com/browse/MGMT-21338)

Depends on https://github.com/lightspeed-core/lightspeed-stack/pull/475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable flag DISABLE_QUERY_MODEL_OVERRIDE (default: false) to control the query model override behavior across environments.
* **Documentation**
  * Updated README to document the new flag alongside the existing system-prompt flag, including default values and HTTP 422 rejection behavior when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->