### PR TITLE
Bump lightspeed-stack for conversation deletion

### DIFF
--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -1,6 +1,6 @@
 # vim: set filetype=dockerfile
-# This is the digest of quay.io/lightspeed-core/lightspeed-stack:dev-20250828-691c83e
-FROM quay.io/lightspeed-core/lightspeed-stack@sha256:f1ec2f3880b0da80279aee20abb1cb20d681b244c17133470bb9399a75bc423e
+# This is the digest of quay.io/lightspeed-core/lightspeed-stack:dev-20250828-c017e78
+FROM quay.io/lightspeed-core/lightspeed-stack@sha256:584ad9805923344ec734e43f220c2c0958411f245341c6dd198739e3ed6e67a1
 
 USER 1001
 USER root

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: all \
 	build-images \
 	build-inspector build-assisted-mcp build-lightspeed-stack build-lightspeed-plus-llama-stack build-ui \
-	generate run resume stop rm logs query query-int query-stage query-interactive mcphost test-eval psql sqlite help
+	generate run resume stop rm logs query query-int query-stage query-interactive delete mcphost test-eval psql sqlite help
 	deploy-template ci-test deploy-template-local
 
 all: help ## Show help information
@@ -93,6 +93,10 @@ query-stage: ## Query the assisted-chat services (stage environment)
 
 query-interactive: query ## Query the assisted-chat services (deprecated, use 'query')
 	@echo "WARNING: 'query-interactive' is deprecated. Use 'make query' instead."
+
+delete: ## Delete a conversation from assisted-chat services
+	@echo "Deleting conversation from assisted-chat services..."
+	DELETE_MODE=true ./scripts/query.sh
 
 mcphost: ## Attach to mcphost
 	@echo "Attaching to mcphost..."

--- a/template.yaml
+++ b/template.yaml
@@ -182,9 +182,6 @@ objects:
         feedback_storage: "${STORAGE_MOUNT_PATH}/feedback"
         transcripts_enabled: ${LIGHTSPEED_TRANSCRIPTS_ENABLED}
         transcripts_storage: "${STORAGE_MOUNT_PATH}/transcripts"
-        data_collector:
-          # We use the external collector as a sidecar
-          enabled: false
       customization:
         system_prompt_path: "${SYSTEM_PROMPT_PATH}"
         disable_query_system_prompt: ${DISABLE_QUERY_SYSTEM_PROMPT}


### PR DESCRIPTION
Bump lightspeed stack to a version containing
https://github.com/lightspeed-core/lightspeed-stack/pull/476

Draft until https://github.com/lightspeed-core/lightspeed-stack/pull/476 merges

lightspeed-stack is now also more strict with not accepting non-existent
config, so we have to remove some old config we used to pass that
doesn't exist anymore, otherwise lightspeed-stack would fail to start.