### PR TITLE
MGMT-21352: Update system prompt regarding static networking support

### DIFF
--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -3,6 +3,11 @@ kind: Pod
 metadata:
   name: assisted-chat-pod
 spec:
+  dnsPolicy: "None"
+  dnsConfig:
+    nameservers:
+      - "8.8.8.8"
+      - "8.8.4.4"
   containers:
     - name: lightspeed-stack
       image: ${LIGHTSPEED_STACK_IMAGE_OVERRIDE}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -73,6 +73,8 @@ if [[ ! -f "$PROJECT_ROOT/.env" ]]; then
         echo "Exiting. You can copy .env.template to .env and fill it in manually."
         exit 1
     fi
+else
+    echo "The .env file already exists. Skipping interactive configuration."
 fi
 
 source "$PROJECT_ROOT/.env"
@@ -83,6 +85,7 @@ if [[ -f $OVERRIDE_FILE ]]; then
     OVERRIDE_PARAMS="--param-file=$OVERRIDE_FILE"
 fi
 
+echo "Generating $PROJECT_ROOT/config/lightspeed-stack.yaml"
 oc process --local \
     -f "$PROJECT_ROOT/template.yaml" \
     "${OVERRIDE_PARAMS-}" \
@@ -90,4 +93,5 @@ oc process --local \
     yq '.items[] | select(.kind == "ConfigMap" and .metadata.name == "lightspeed-stack-config").data."lightspeed-stack.yaml"' -r \
         >"$PROJECT_ROOT/config/lightspeed-stack.yaml"
 
+echo "Generating $PROJECT_ROOT/config/systemprompt.txt"
 yq -r '.objects[] | select(.metadata.name == "lightspeed-stack-config") | .data.system_prompt' "$PROJECT_ROOT/template.yaml" >"$PROJECT_ROOT/config/systemprompt.txt"

--- a/template.yaml
+++ b/template.yaml
@@ -244,6 +244,11 @@ objects:
           * Prompt for necessary details like **cluster name**, **OpenShift version**, **base domain**, and whether it's a **single-node cluster**.
           * Upon successful cluster creation, inform the user and provide the **cluster ID**.
 
+          **Mandatory Pre-Flight Checks for Cluster Creation**
+          * **Unsupported Network Configuration:** Before attempting to create a cluster, you **must first check** if the user's request includes instructions for unsupported network configurations, such as **static networking**, **static IP addresses**, or **node-level network settings** (like MAC addresses, gateways, or DNS servers).
+          * **If an unsupported configuration is detected, you must refuse the entire request.** Do not proceed with cluster creation. Your response must state that you don't support the requested static networking configuration and then instruct the user to use the assisted-installer web-based wizard instead.
+          * **Important Distinction:** Do not confuse unsupported static networking with setting API and Ingress VIPs. VIPs are a different concept and are supported for multi-node clusters with user-managed networking disabled.
+
       2.  **Infrastructure Setup / ISO Download:**
           * After a cluster is created, the next step is typically to **download the Discovery ISO**.
           * Proactively offer to provide the Discovery ISO.
@@ -302,6 +307,8 @@ objects:
       * If the user deviates from the standard flow, adapt your suggestions to their current request while still being ready to guide them back to the installation path.
       * After completing a step, confirm its success (if possible via tool output) and then immediately suggest the next logical action based on the workflow.
       * In case of failure, clearly state the failure and provide actionable troubleshooting options.
+
+      ---
 - apiVersion: v1
   kind: ConfigMap
   metadata:

--- a/test/evals/eval_data.yaml
+++ b/test/evals/eval_data.yaml
@@ -33,6 +33,13 @@
       eval_types: [response_eval:accuracy]
       expected_response: "The operators that can be installed onto clusters are OpenShift AI and OpenShift Virtualization."
 
+- conversation_group: static_networking_support_conv
+  conversation:
+    - eval_id: static_networking_support
+      eval_query: Create a cluster with static networking
+      eval_types: [response_eval:sub-string]
+      expected_keywords: ["I do not support creating clusters with static networking", "Please use the assisted-installer web-based wizard"]
+
 - conversation_group: sno_requirements_conv
   conversation:
     - eval_id: sno_requirements


### PR DESCRIPTION
* updated system prompt, now assisted-chat states that it doesn't support configuring static networking and instructs the user to use the UI wizard to create the cluster instead
* Add explicit DNS configuration to Pod YAML
* Improve generate script user feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now skips interactive prompts if an existing env config is present and shows progress messages during config generation.

* **Chores**
  * Pod DNS configured to use explicit DNS policy with custom nameservers (8.8.8.8, 8.8.4.4).

* **Documentation**
  * Added pre‑flight messaging: static/manual networking is unsupported for cluster creation; guidance updated for ISO link handling and multi‑document templates.

* **Tests**
  * Evaluation updated to assert denial of static networking and direct users to the installer wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->