### PR TITLE
MGMT-21661: Tooling for Archive Data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 .PHONY: all \
 	build-images \
 	build-inspector build-assisted-mcp build-lightspeed-stack build-lightspeed-plus-llama-stack build-ui \
-	generate run resume stop rm logs query query-int query-stage query-prod query-interactive delete mcphost test-eval psql sqlite help
-	deploy-template ci-test deploy-template-local
+	deploy-template ci-test deploy-template-local \
+	generate run resume stop rm logs query query-int query-stage query-prod query-interactive delete mcphost test-eval psql sqlite transcript-summaries-prod help
 
 all: help ## Show help information
 
@@ -121,6 +121,10 @@ sqlite: ## Copy SQLite database from pod and open in browser
 	@podman cp assisted-chat-pod-lightspeed-stack:/tmp/assisted-chat.db /tmp/assisted-chat.db
 	@echo "Opening SQLite database in browser..."
 	@sqlitebrowser /tmp/assisted-chat.db
+
+transcript-summaries-prod:
+	./scripts/archives/download-and-extract prod
+	./scripts/archives/summarize-transcripts
 
 help: ## Show this help message
 	@echo "Available targets:"

--- a/scripts/archives/.gitignore
+++ b/scripts/archives/.gitignore
@@ -1,0 +1,3 @@
+from-s3/
+extracted/
+summaries/

--- a/scripts/archives/README.md
+++ b/scripts/archives/README.md
@@ -1,0 +1,31 @@
+# Data Archive Tools
+
+This directory contains a set of scripts to help with processing the data collected from lightspeed
+(transcripts and feedback requests).
+
+To sync that latest archive data from s3, run:
+
+`$ ./download-and-extract prod`
+
+(replacing `prod` with `stage` if you want integration/stage data). This requires your local
+Kerberos to be setup for an internal RedHat user.
+
+This puts all of the extracted archives in the local `extracted` directory. Feedback is directly
+viewable in there. The transcripts are also there but each query/response pair is a separate file so
+it isn't very easy to view.
+
+If you then want to aggregate all of the transcripts and correlate them to any feedback for a single
+conversation, run:
+
+`$ ./summarize-transcripts`
+
+and everything in the `extracted` dir will be summarized and put into the `summaries` dir. The
+file names are the conversation ids. Any feedback associated with that conversation will be put
+inline with the conversation chat history, along with tool calls to the MCP server.
+
+## Env Requirements
+
+- https://github.com/app-sre/rh-aws-saml-login
+- Python 3.12+
+- AWS cli tool
+- Local kerberos setup for RedHat internal user

--- a/scripts/archives/download-and-extract
+++ b/scripts/archives/download-and-extract
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Download and extract the transcript/feedback tgz archives from S3 using local user authentication
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -euo pipefail
+
+ENV=${1:-prod}
+
+ACCOUNT=""
+if [[ $ENV == "prod" ]]; then
+  ACCOUNT="insights-prod-rh"
+elif [[ $ENV == "stage" ]]; then
+  ACCOUNT="crc-stage"
+else
+  echo "Usage: $0 prod|stage"
+  exit 1
+fi
+
+rm -rf $SCRIPT_DIR/from-s3/*
+
+rh-aws-saml-login $ACCOUNT -- aws s3 sync --exclude '*' --include 'ocm-assisted-chat/*' s3://rh-lightspeed-assistant-archives-$ENV $SCRIPT_DIR/from-s3
+
+rm -rf $SCRIPT_DIR/extracted/*
+mkdir -p $SCRIPT_DIR/extracted
+cat $(find $SCRIPT_DIR/from-s3 -name "*.tgz") | tar -xzvf - -i -C $SCRIPT_DIR/extracted

--- a/scripts/archives/summarize-transcripts
+++ b/scripts/archives/summarize-transcripts
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Summarize the transcript data into a more useful format
+
+from dataclasses import dataclass
+from datetime import datetime
+import shutil
+from dateutil.parser import parse
+import json
+import pathlib
+from typing import Any
+
+SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
+OUT_DIR = SCRIPT_DIR / "summaries"
+
+def main():
+    shutil.rmtree(OUT_DIR, ignore_errors=True)
+    OUT_DIR.mkdir(exist_ok=True)
+    feedback = feedback_by_conv_query()
+    for path, dirs, files in (SCRIPT_DIR / "extracted/transcripts").walk():
+        json_files = [f for f in files if f.endswith("json")]
+        if not json_files:
+            continue
+
+        ts, conv_id, summary = summarize_conversation(path, [path /f for f in json_files], feedback)
+        with open(OUT_DIR / conv_id, "w") as fd:
+            fd.write(summary)
+
+def conv_query_key(conv_id: str, user_question: str):
+    return f"{conv_id}|{user_question}"
+
+def feedback_by_conv_query():
+    by_key = {}
+    for f in (SCRIPT_DIR / "extracted/feedback").glob("**/*.json"):
+        parsed = json.loads(f.read_text())
+        by_key[conv_query_key(parsed["conversation_id"], parsed["user_question"])] = parsed
+    return by_key
+
+@dataclass
+class ConvoPair:
+    timestamp: datetime
+    query: str
+    response: str
+    attachments: list[Any]
+    tool_calls: list[Any]
+
+def summarize_conversation(base_path: pathlib.Path, json_files: list[pathlib.Path], feedback: dict[str, Any]):
+    provider = None
+    model = None
+    user_id = None
+    conv_id = None
+
+    pairs: list[ConvoPair] = []
+    for f in json_files:
+        with f.open('r') as fd:
+            parsed = json.load(fd)
+
+            provider = parsed["metadata"]["provider"]
+            model = parsed["metadata"]["model"]
+            user_id = parsed["metadata"]["user_id"]
+            conv_id = parsed["metadata"]["conversation_id"]
+
+            ts = parsed["metadata"]["timestamp"]
+            query = parsed["redacted_query"]
+            response = parsed["llm_response"]
+            attachments = parsed["attachments"]
+            tool_calls = parsed.get("tool_calls", [])
+
+            pairs.append(ConvoPair(
+                timestamp=parse(ts),
+                query=query,
+                response=response,
+                attachments=attachments,
+                tool_calls=tool_calls,
+            ))
+
+    pairs = sorted(pairs, key=lambda p: p.timestamp)
+    start_time = pairs[0].timestamp
+    out = f"Conversation ID: {conv_id}\n"
+    out += f"Model: {model}\n"
+    out += f"Provider: {provider}\n"
+    out += f"Starting Time: {start_time.strftime("%Y/%m/%d %H:%M:%S %Z")}\n"
+    out += f"User ID: {user_id}\n\n"
+
+    for p in pairs:
+        out += f"[{p.timestamp.strftime("%H:%M:%S")}]\n"
+        out += f"User: {p.query}\n\n"
+        out += f"Assisted Chat: {p.response}\n"
+        if p.tool_calls:
+            out += f"Tool calls: {json.dumps(p.tool_calls, indent=2)}\n"
+        feedback_key = conv_query_key(conv_id, p.query)
+        if feedback_key in feedback:
+            f = feedback[feedback_key]
+            if f["sentiment"] > 0:
+                out += "User: <THUMBS UP> (Positive Feedback)\n"
+            else:
+                out += f"User: <THUMBS DOWN> (Negative Feedback) - {f["user_feedback"]} (Categories: {f["categories"]})\n"
+        out += "\n"
+
+    return start_time, conv_id, out
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This gives us scripts to download/extract/summarize the transcript/feedback data that is exported to s3 from lightspeed.

It will pull all of the data about a single conversation, including feedback and MCP tool calls into a single file per conversation. This should make it easier to get a overall view of a conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI tools to download archives from cloud, extract them locally, and generate per-conversation summary files (supports prod/stage); Makefile target to run the full workflow.

* **Documentation**
  * Added README explaining the archive tools, environment requirements, sync/extract steps, and how to run summarization.

* **Chores**
  * Added ignore rules to exclude downloaded archives, extracted data, and generated summaries from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->