### PR TITLE
no need for getting the exit status of the pod when the logs are being colletcted

### DIFF
--- a/scripts/ci_test.sh
+++ b/scripts/ci_test.sh
@@ -56,7 +56,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
         echo "The evaluation tests failed, you can see the logs of the pods under the directory artifacts/eval-test/gather-extra/artifacts/pods/."
         echo "oc events"
         oc events -n "$NAMESPACE"
-        exit "$(oc get pod "$POD_NAME" -n "$NAMESPACE" -o=jsonpath='{.status.containerStatuses[0].lastState.terminated.exitCode}')"
+        exit 1
     fi
 
     echo "Waiting for pod $POD_NAME to be ready..."


### PR DESCRIPTION
This PR is needed because one successful merge needs to happen so the promotion of CI built images would start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI test failure exit status to always return 1, improving consistency in build pipelines and reporting.
  * Streamlines failure handling and reduces variability in automated tooling behavior.
  * No changes to application functionality or user interface.
  * Developers and CI systems can rely on a uniform failure code for clearer diagnostics and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->