### PR TITLE
Add make query-prod target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: all \
 	build-images \
 	build-inspector build-assisted-mcp build-lightspeed-stack build-lightspeed-plus-llama-stack build-ui \
-	generate run resume stop rm logs query query-int query-stage query-interactive delete mcphost test-eval psql sqlite help
+	generate run resume stop rm logs query query-int query-stage query-prod query-interactive delete mcphost test-eval psql sqlite help
 	deploy-template ci-test deploy-template-local
 
 all: help ## Show help information
@@ -90,6 +90,10 @@ query-int: ## Query the assisted-chat services (integration environment)
 query-stage: ## Query the assisted-chat services (stage environment)
 	@echo "Querying assisted-chat services (stage environment)..."
 	QUERY_ENV=stage ./scripts/query.sh
+
+query-prod: ## Query the assisted-chat services (production environment)
+	@echo "Querying assisted-chat services (production environment)..."
+	QUERY_ENV=prod ./scripts/query.sh
 
 query-interactive: query ## Query the assisted-chat services (deprecated, use 'query')
 	@echo "WARNING: 'query-interactive' is deprecated. Use 'make query' instead."

--- a/scripts/query.sh
+++ b/scripts/query.sh
@@ -24,6 +24,9 @@ case "${QUERY_ENV:-}" in
     "stage")
         BASE_URL="https://assisted-chat.api.stage.openshift.com"
         ;;
+    "prod")
+        BASE_URL="https://assisted-chat.api.openshift.com"
+        ;;
     *)
         BASE_URL="http://localhost:8090"
         ;;


### PR DESCRIPTION
We only had for int/stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a production environment option to the query command, consistent with existing integration and staging options.
  - Updated the query tool to support the production API endpoint, improving parity across environments.
  - No changes to user-facing functionality; existing commands and behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->