### PR TITLE
Bump lightspeed-stack to dev-20250904-3c0c98b

### DIFF
--- a/Containerfile.assisted-chat
+++ b/Containerfile.assisted-chat
@@ -1,6 +1,6 @@
 # vim: set filetype=dockerfile
-# This is the digest of quay.io/lightspeed-core/lightspeed-stack:dev-20250902-be56d50
-FROM quay.io/lightspeed-core/lightspeed-stack@sha256:1a27cbd2204e2bb843988dda100011b75b9619426c1efec83549e4945f9bb34a
+# This is the digest of quay.io/lightspeed-core/lightspeed-stack:dev-20250904-3c0c98b
+FROM quay.io/lightspeed-core/lightspeed-stack@sha256:de47235addac063d647c741921de754b7413b0af6384c460291100e1a20d301c
 
 USER 1001
 USER root

--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -34,7 +34,7 @@ spec:
         - mountPath: /tmp/systemprompt.txt
           name: config
           subPath: systemprompt.txt
-        - mountPath: /tmp/vertex-credentials.json
+        - mountPath: /tmp/vertex-credentials.json:Z
           name: config
           subPath: vertex-credentials.json
           readOnly: true

--- a/template-params.dev.env
+++ b/template-params.dev.env
@@ -7,4 +7,4 @@ DISABLE_QUERY_SYSTEM_PROMPT=false
 ASSISTED_CHAT_DEFAULT_MODEL=gemini/gemini-2.0-flash
 LIGHTSSPEED_STACK_POSTGRES_SSL_MODE=disable
 AUTHN_ROLE_RULES='[{"jsonpath":"$.realm_access.roles[*]","operator":"contains","value":"redhat:employees","roles":["redhat_employee"]},{"jsonpath":"$.email","operator":"match","value":".*@redhat\\\\.com$","roles":["redhat_employee"]}]'
-AUTHZ_ACCESS_RULES='[{"role":"redhat_employee","actions":["get_models","query","streaming_query","get_conversation","list_conversations","delete_conversation","feedback","info","get_metrics"]}]'
+AUTHZ_ACCESS_RULES='[{"role":"redhat_employee","actions":["get_models","query","streaming_query","get_conversation","list_conversations","delete_conversation","feedback","info","get_metrics", "get_config", "model_override"]}]'


### PR DESCRIPTION
Contains two important changes:

- New authz permission to block model / provider overrides via the API
- Censorship of sensitive info in the get_config endpoint

This means we can now allow employees to use get_config without worrying about them seeing sensitive info like API keys.

Also we're going to allow employees to override the provider/model via the API