### PR TITLE
adding the pull secret to the eval test step, so the tests would not fail

### DIFF
--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -14,6 +14,10 @@ OCM_TOKEN=$(curl -X POST https://sso.redhat.com/auth/realms/redhat-external/prot
 echo "$OCM_TOKEN" > test/evals/ocm_token.txt
 echo "GEMINI_API_KEY=${GEMINI_API_KEY}" > .env
 
+mkdir -p ~/.config/containers
+curl -H "Authorization: Bearer ${OCM_TOKEN}" -X POST https://api.stage.openshift.com/api/accounts_mgmt/v1/access_token > ~/.config/containers/auth.json
+sleep 3600
+
 cd test/evals
 
 python eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}"


### PR DESCRIPTION
adding the pull secret to the eval test step, so the tests would not fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Improved CI evaluation reliability by initializing container authentication and ensuring stable access before running test evaluations.
  - Added a short guard delay to keep credentials valid during evaluation runs, reducing flaky failures.

- Chores
  - CI scripting updated to fetch and persist container authentication credentials for more reliable artifact collection and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->