### PR TITLE
Remove the dnsPolicy from assisted-chat-pod.yaml

### DIFF
--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -3,11 +3,6 @@ kind: Pod
 metadata:
   name: assisted-chat-pod
 spec:
-  dnsPolicy: "None"
-  dnsConfig:
-    nameservers:
-      - "8.8.8.8"
-      - "8.8.4.4"
   containers:
     - name: lightspeed-stack
       image: ${LIGHTSPEED_STACK_IMAGE_OVERRIDE}


### PR DESCRIPTION
Seems to cause an issue resolving sso.redhat.com
"Cannot connect to host sso.redhat.com:443 ssl:default [Name or service not known]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed custom DNS overrides so the deployment now uses the cluster’s default DNS behavior.
  * No changes to containers, ports, environment variables, or volumes; no user-facing functionality changes expected.
  * Network/DNS resolution will follow platform defaults; no action required from end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->