### PR TITLE
use temp directory for eval test entrypoint

### DIFF
--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -11,9 +11,14 @@ OCM_TOKEN=$(curl -X POST https://sso.redhat.com/auth/realms/redhat-external/prot
   -d "client_id=$CLIENT_ID" \
   -d "client_secret=$CLIENT_SECRET" | jq '.access_token' | sed "s/^['\"]*//; s/['\"]*$//")
 
-echo "$OCM_TOKEN" > test/evals/ocm_token.txt
+WORK_DIR=$(pwd)
+TEMP_DIR=$(mktemp -d)
+
+cd $TEMP_DIR
+
+echo "$OCM_TOKEN" > ocm_token.txt
 echo "GEMINI_API_KEY=${GEMINI_API_KEY}" > .env
 
-cd test/evals
+TEST_DIR="${WORK_DIR}/test/evals"
 
-python eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}"
+python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEST_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21415

when trying to run the test in an OpenShift cluster the following error is recieved:
```
/opt/app-root/src/test/prow/entrypoint.sh: line 14: test/evals/ocm_token.txt: Permission denied
```

this PR introduces usage of a temp dir to avoid permission issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated evaluation runner to use a temporary workspace and environment file for isolated runs and more secure secret handling.
  - Invokes the evaluation script via an absolute path and passes explicit configuration parameters for consistency.

- **Chores**
  - Removed brittle directory assumptions in test scripts to improve CI reliability.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->