### PR TITLE
add random job id to eval tests template

### DIFF
--- a/test/prow/template.yaml
+++ b/test/prow/template.yaml
@@ -6,7 +6,7 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: assisted-chat-eval-test
+    name: assisted-chat-eval-test-${JOB_ID}
     labels:
       app: assisted-chat-eval-test
   spec:
@@ -43,6 +43,9 @@ objects:
             value: ${AGENT_PORT}
 
 parameters:
+- name: JOB_ID
+  generate: expression
+  from: "[0-9a-f]{7}"
 - name: IMAGE_NAME
   required: true
 - name: SSL_CLIENT_SECRET_NAME


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21415

this change will cause a new job to be created after each deployment, guaranteeing more reliable results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI jobs now use dynamically generated names with a short unique ID appended, improving traceability across runs and reducing name collisions.
  * Introduced a template parameter to auto-generate the short ID, ensuring each job run is distinguishable without manual input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->