### PR TITLE
fix location of ocm_token in test entry point

### DIFF
--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -21,4 +21,4 @@ echo "GEMINI_API_KEY=${GEMINI_API_KEY}" > .env
 
 TEST_DIR="${WORK_DIR}/test/evals"
 
-python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEST_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml
+python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEMP_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21415

fixes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluation workflow to read the authentication token from the temporary directory where it’s generated, ensuring the evaluator receives the correct token file.
  * Improves consistency between setup and execution steps, reducing flakiness and missing-file errors in automated runs.
  * No changes to application behavior or user-facing features; this only affects test and CI reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->