### PR TITLE
fix eval tests for substring matching

### DIFF
--- a/test/evals/eval_data.yaml
+++ b/test/evals/eval_data.yaml
@@ -42,7 +42,7 @@
     - eval_id: static_networking_support
       eval_query: Create a cluster with static networking
       eval_types: [response_eval:sub-string]
-      expected_keywords: ["I do not support creating clusters with static networking", "Please use the assisted-installer web-based wizard"]
+      expected_keywords: ["I do not support creating clusters with static networking", "assisted-installer web-based wizard"]
 
 - conversation_group: sno_requirements_conv
   conversation:
@@ -175,7 +175,7 @@
     - eval_id: create_single_node_cluser
       eval_query: Create a multi-node cluster named 'eval-test-cluster-name' with OpenShift 4.18.22 and domain test.local. I do not have an SSH key to provide.
       eval_types: [response_eval:sub-string]
-      expected_keywords: ["cluster", "eval-test-cluster-name", "cluster ID"]
+      expected_keywords: ["cluster", "eval-test-cluster-name", "ID"]
     - eval_id: cluster_name_tool_call
       eval_query: Show me information on cluster eval-test-cluster-name
       eval_types: [tool_eval, response_eval:sub-string]


### PR DESCRIPTION
fix eval tests to be more permissive according to the following reponses:
- `I do not support creating clusters with static networking configurations through this interface. Static networking configurations must be configured through the assisted-installer web-based wizard.`
- `I have created the 'eval-test-cluster-name' cluster with ID`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated expected keyword phrases in evaluation test data to align with current phrasing conventions.
  * Adjusted wording by removing polite prefixes and standardizing identifier terminology across duplicated cases.
  * No impact on application behavior or user workflows.

* **Chores**
  * Maintenance of test datasets to improve consistency and reduce false negatives during automated evaluations.

* **Note**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->