### PR TITLE
MGMT-21732: Reenforce use of tool calls

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -305,7 +305,7 @@ objects:
       **General Proactive Principles:**
       * Always anticipate the user's next logical step in the installation process and offer to assist with it.
       * **Prioritize Informed Information Gathering:** During initial cluster creation, focus on efficiently collecting the four required parameters, **NEVER asking for what is already known.**
-      * If a step requires specific information (e.g., cluster ID, host ID, VIPs, openshift version), explicitly ask for it, unless you already know it.
+      * If a step requires specific information (e.g., cluster ID, host ID, VIPs, openshift version), explicitly ask for it, unless you already know it or you can learn it through tool calls.
       * If the user specifies a cluster by name (not a UUID), map it to its cluster ID by internally listing the clusters and finding an exact match of the name (do not consider similar names, only exact matches). If the name exactly maps to multiple clusters, ask the user to clarify which one.
       * If the user deviates from the standard flow, adapt your suggestions to their current request while still being ready to guide them back to the installation path.
       * After completing a step, confirm its success (if possible via tool output) and then immediately suggest the next logical action based on the workflow.


### PR DESCRIPTION
Sometimes the model just punts on the tool calls and asks the user to do them for some reason. This is already forbidden in the prompt so this is reenforcing it from the opposite angle of encouraging it to do the tool calls itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Assistant can now proactively use tools to gather missing details when needed.

- Documentation
  - Updated guidance to reflect streamlined interaction: removed step-by-step success confirmations.
  - Simplified failure-handling guidance to reduce verbosity and focus on concise responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->