### PR TITLE
eval tests copy eval_data to temp dir to avoid permission issues

### DIFF
--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -20,6 +20,7 @@ cd $TEMP_DIR
 echo "$OCM_TOKEN" > ocm_token.txt
 echo "GEMINI_API_KEY=${GEMINI_API_KEY}" > .env
 
-sed -i "s/uniq-cluster-name/${UNIQUE_ID}/g" $TEST_DIR/eval_data.yaml
+cp $TEST_DIR/eval_data.yaml $TEMP_DIR/eval_data.yaml
+sed -i "s/uniq-cluster-name/${UNIQUE_ID}/g" $TEMP_DIR/eval_data.yaml
 
-python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEMP_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml
+python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEMP_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml --eval_data_yaml $TEMP_DIR/eval_data.yaml


### PR DESCRIPTION
```
$ oc logs assisted-chat-eval-test-c563a1e-wqgnp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1720  100  1597  100   123   4084    314 --:--:-- --:--:-- --:--:--  4398
sed: couldn't open temporary file /opt/app-root/src/test/evals/sedC4Jili: Permission denied
```

this output is from running the tests in a managed openshift cluster.