### PR TITLE
making the evaluation tests more stable

### DIFF
--- a/assisted-chat-pod.yaml
+++ b/assisted-chat-pod.yaml
@@ -47,6 +47,10 @@ spec:
       env:
         - name: TRANSPORT
           value: streamable-http
+        - name: INVENTORY_URL
+          value: "https://api.stage.openshift.com/api/assisted-install/v2"
+        - name: PULL_SECRET_URL
+          value: "https://api.stage.openshift.com/api/accounts_mgmt/v1/access_token"
     - name: ui
       image: localhost/local-ai-chat-ui
       env:

--- a/scripts/eval_k8s.sh
+++ b/scripts/eval_k8s.sh
@@ -17,5 +17,11 @@ fi
 bash "$PROJECT_ROOT/utils/port_forward.sh"
 
 # Run evaluation
+UNIQUE_ID=$(head /dev/urandom | tr -dc 0-9a-z | head -c 8)
+export UNIQUE_ID
+export TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+cp test/evals/eval_data.yaml "${TEMP_DIR}/eval_data.yaml"
+sed -i "s/uniq-cluster-name/${UNIQUE_ID}/g" "${TEMP_DIR}/eval_data.yaml"
 cd "${PROJECT_ROOT}/test/evals"
-python eval.py --agent_endpoint "http://localhost:${ASSISTED_CHAT_PORT}" 
+python eval.py --agent_endpoint "http://localhost:${ASSISTED_CHAT_PORT}" --eval_data_yaml "${TEMP_DIR}/eval_data.yaml"

--- a/template.yaml
+++ b/template.yaml
@@ -207,7 +207,7 @@ objects:
       **Capabilities and Scope:**
       - Supported: On-premise OpenShift installs via Assisted Installer on baremetal hosts or VMs (e.g., vSphere, KVM, libvirt).
       - Not supported: Public clouds (AWS, Azure, GCP) or any non-Assisted platforms/hosted services.
-      - Behavior: If asked for out-of-scope actions (e.g., "create on AWS"), briefly decline, state the scope, and offer guidance to the relevant OpenShift Installer/ROSA/ARO documentation or workflows.
+      - Behavior: If asked for out-of-scope actions (e.g., "create on AWS"), briefly decline, state the scope, and offer guidance to the relevant OpenShift Installer/Red Hat OpenShift Service on AWS (ROSA)/ Azure Red Hat OpenShift (ARO) documentation or workflows.
 
       ---
 
@@ -322,7 +322,11 @@ objects:
       * Always anticipate the user's next logical step in the installation process and offer to assist with it.
       * **Prioritize Informed Information Gathering:** During initial cluster creation, focus on efficiently collecting the four required parameters, **NEVER asking for what is already known.**
       * If a step requires specific information (e.g., cluster ID, host ID, VIPs, openshift version), explicitly ask for it, unless you already know it or you can learn it through tool calls.
-      * If the user specifies a cluster by name (not a UUID), map it to its cluster ID by internally listing the clusters and finding an exact match of the name (do not consider similar names, only exact matches). If the name exactly maps to multiple clusters, ask the user to clarify which one.
+      * When a cluster name is provided (not a UUID), strictly adhere to this logic:
+          * Perform a search for an EXACT string match against all known cluster names. Ignore and discard all partial or similar name matches.
+          * If exactly one exact match is found, immediately map the name to its Cluster ID and proceed with the operation.
+          * If multiple exact matches are found, ask the user to clarify which cluster ID should be used.
+          * ONLY if no exact matches are found in the cluster list, ask the user to provide the Cluster ID.
       * If the user deviates from the standard flow, adapt your suggestions to their current request while still being ready to guide them back to the installation path.
       * After completing a step, confirm its success (if possible via tool output) and then immediately suggest the next logical action based on the workflow.
       * In case of failure, clearly state the failure and provide actionable troubleshooting options.

--- a/test/evals/eval.py
+++ b/test/evals/eval.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import sys
+import os
 
 from lsc_agent_eval import AgentGoalEval
 
@@ -80,6 +81,9 @@ def parse_args():
 
 # Parse command line arguments
 args = parse_args()
+if os.getenv('UNIQUE_ID') is None:
+    print("The environmental varialbe 'UNIQUE_ID' has to be set so the cluster creation and removal can happen properly.")
+    sys.exit(1)
 
 evaluator = AgentGoalEval(args)
 # Run Evaluation
@@ -88,7 +92,7 @@ evaluator.run_evaluation()
 result_summary = evaluator.get_result_summary()
 
 failed_evals_count = result_summary["FAIL"] + result_summary["ERROR"]
-if failed_evals_count > 2:
+if failed_evals_count:
     print(f"❌ {failed_evals_count} evaluation(s) failed!")
     sys.exit(1)
 

--- a/test/evals/eval_data.yaml
+++ b/test/evals/eval_data.yaml
@@ -52,10 +52,11 @@
 
 - conversation_group: sno_creation_with_all_info_conv
   description: Create SNO and then retrieve Discovery ISO in two steps with all the information provided
+  cleanup_script: ../scripts/delete_cluster.sh
   conversation:
     - eval_id: create_eval_test_sno
       eval_query: create a new single node cluster named eval-test-singlenode-uniq-cluster-name, running on version 4.19.7 with the x86_64 CPU architecture, configured under the base domain example.com, using the provided SSH key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCmeaBFhSJ/MLECmqUaKweRgo10ABpwdvJ7v76qLYfP0pzfzYsF3hGP/fH5OQfHi9pTbWynjaEcPHVfaTaFWHvyMtv8PEMUIDgQPWlBSYzb+3AgQ5AsChhzTJCYnRdmCdzENlV+azgtb3mVfXiyCfjxhyy3QAV4hRrMaVtJGuUQfQ== example@example.com".
-      eval_types: [tool_eval, response_eval:sub-string, response_eval:accuracy]
+      eval_types: [tool_eval, response_eval:sub-string, response_eval:accuracy, action_eval]
       expected_tool_calls:
         - - tool_name: create_cluster
             arguments:
@@ -65,6 +66,8 @@
               single_node: "(?i:true)"
               cpu_architecture: "x86_64"
               ssh_public_key: 'ssh-rsa\s+[A-Za-z0-9+/]+[=]{0,3}(\s+.+)?\s*'
+              platform: "none"
+      eval_verify_script: ../scripts/cluster_created_check.sh
       expected_keywords: ["eval-test-singlenode-uniq-cluster-name", "ID", "Discovery ISO", "download", "cluster"]
       expected_response: I have created a cluster with name eval-test-singlenode-uniq-cluster-name. Next, you'll need to download the Discovery ISO, then boot your hosts with it. Would you like me to get the Discovery ISO download URL?
     - eval_id: get_iso_eval_test_sno
@@ -78,10 +81,11 @@
 
 - conversation_group: mno_cluster_workflow_conv
   description: Create multi-node cluster and then retrieve ISO in two steps
+  cleanup_script: ../scripts/delete_cluster.sh
   conversation:
     - eval_id: create_eval_test_multinode
-      eval_types: [tool_eval, response_eval:accuracy, response_eval:sub-string]
-      eval_query: Create a multi-node cluster named 'eval-test-multinode-uniq-cluster-name' with OpenShift 4.18.22 and domain test.local
+      eval_types: [tool_eval, response_eval:accuracy, response_eval:sub-string, action_eval]
+      eval_query: Create a multi-node cluster named 'eval-test-multinode-uniq-cluster-name' with OpenShift 4.18.22 and domain test.local and with the x86_64 CPU architecture.
       expected_tool_calls:
         - - tool_name: create_cluster
             arguments:
@@ -89,10 +93,12 @@
               version: "4\\.18\\.22"
               base_domain: "test\\.local"
               single_node: "(?i:false)"
-              cpu_architecture: None
-              ssh_public_key: None
+              cpu_architecture: "x86_64"
+              ssh_public_key: ""
+              platform: "baremetal"
+      eval_verify_script: ../scripts/cluster_created_check.sh
       expected_keywords: ["eval-test-multinode-uniq-cluster-name", "ID", "Discovery ISO", "cluster"]
-      expected_response: I have created a cluster with name eval-test-multinode-uniq-cluster-name. Next, you'll need to download the Discovery ISO, then boot your hosts with it. Would you like me to get the Discovery ISO download URL?
+      expected_response: I have created a cluster with name eval-test-multinode-uniq-cluster-name. Before downloading the Discovery ISO, would you like to configure static network configuration for the hosts? If not, the cluster will use Dynamic Host Configuration Protocol (DHCP) for host networking configuration by default.
     - eval_id: set_ssh_key_eval_test_ssh
       eval_query: Set the SSH key for the cluster you just created to "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCmeaBFhSJ/MLECmqUaKweRgo10ABpwdvJ7v76qLYfP0pzfzYsF3hGP/fH5OQfHi9pTbWynjaEcPHVfaTaFWHvyMtv8PEMUIDgQPWlBSYzb+3AgQ5AsChhzTJCYnRdmCdzENlV+azgtb3mVfXiyCfjxhyy3QAV4hRrMaVtJGuUQfQ== example@example.com"
       eval_types: [tool_eval, response_eval:accuracy]
@@ -111,12 +117,8 @@
               cluster_id: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
       expected_keywords: ["Discovery ISO"]
     - eval_id: host_booted_but_not_discovered
-      eval_query: I booted the hosts
-      eval_types: [tool_eval, response_eval:accuracy]
-      expected_tool_calls:
-        - - tool_name: cluster_info
-            arguments:
-              cluster_id: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+      eval_query: I booted the hosts for the cluster you just created
+      eval_types: [response_eval:accuracy]
       expected_response: "hosts hasn't been discovered yet."
 
 - conversation_group: list_clusters_conv
@@ -143,7 +145,7 @@
   description: Validate graceful handling of invalid SSH key format
   conversation:
     - eval_id: invalid_ssh_key_handling
-      eval_query: create a new single node cluster named eval-test-sno, running on version 4.19.7, configured under the base domain example.com, using the provided SSH key abc123def456.
+      eval_query: create a new single node cluster named eval-test-sno, running on version 4.19.7, configured under the base domain example.com, and with cpu architecture x86_64 using the provided SSH key abc123def456.
       eval_types: [response_eval:accuracy]
       expected_response: The cluster creation failed because the provided SSH key is not in a supported format. Please provide the SSH key in one of these formats ssh-rsa, ssh-ed25519 or ecdsa.
 
@@ -159,8 +161,8 @@
   conversation:
     - eval_id: refuse_azure_request
       eval_query: Can you create a cluster on Azure?
-      eval_types: [response_eval:sub-string]
-      expected_keywords: ["Azure", "cannot create", "Assisted Installer", "on-prem"]
+      eval_types: [response_eval:accuracy]
+      expected_response: Sorry, I can't create clusters directly on public clouds like Azure. I am designed to assist with on-premise OpenShift installations using the Assisted Installer. For installing OpenShift on Azure, you can explore Red Hat OpenShift Service on Azure or use the standard OpenShift Installer.
       description: Refuse out-of-scope request to create clusters on Azure; clarify on-prem scope and Assisted Installer
 
 - conversation_group: capabilities_scope_conv
@@ -168,56 +170,54 @@
     - eval_id: supported_platforms_summary
       eval_query: Which platforms can you help me install on?
       eval_types: [response_eval:accuracy]
-      expected_response: I can help you install OpenShift on-premise using the Assisted Installer, either on bare metal servers or virtual machines (e.g., vSphere, KVM, libvirt). I do not support public cloud platforms like AWS, Azure, or GCP.
+      expected_response: I can help you install OpenShift on-premise using the Assisted Installer, either on bare metal servers or virtual machines (e.g., vSphere, KVM, libvirt). I do not support public cloud platforms like Amazon Web Services (AWS), Azure, or Google Cloud Platform (GCP).
       description: Ensure the assistant concisely states supported on-prem baremetal/VM scope and references Assisted Installer
 
 - conversation_group: cluster_id_from_name
+  setup_script: ../scripts/cluster_create_test_setup.sh
+  cleanup_script: ../scripts/delete_cluster.sh
   conversation:
-    - eval_id: create_single_node_cluser
-      eval_query: Create a multi-node cluster named 'eval-test2-uniq-cluster-name' with OpenShift 4.18.22 and domain test.local. I do not have an SSH key to provide.
-      eval_types: [response_eval:accuracy, response_eval:sub-string]
-      expected_keywords: ["eval-test2-uniq-cluster-name", "ID", "Discovery ISO", "download", "cluster"]
-      expected_response: I have created a cluster with name eval-test-uniq-cluster-name. Next, you'll need to download the Discovery ISO, then boot your hosts with it. Would you like me to get the Discovery ISO download URL?
     - eval_id: cluster_name_tool_call
-      eval_query: Show me information on cluster eval-test2-uniq-cluster-name
+      eval_query: Show me all the available information on cluster named 'eval-testcluster-uniq-cluster-name'
       eval_types: [tool_eval, response_eval:sub-string]
       expected_tool_calls:
+        - - tool_name: list_clusters
+            arguments: {}
         - - tool_name: cluster_info
             arguments:
               cluster_id: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
-      expected_keywords: ["cluster", "eval-test2-uniq-cluster-name", "test.local", "4.18.22"]
+      expected_keywords: ["cluster", "eval-testcluster-uniq-cluster-name", "4.18.22"]
       description: Test handling requesting a cluster by name
 
 - conversation_group: static_net_config_vlan
-  description: Configure a basic static network config for two hosts with vlans
+  description: Configure a basic static network config for the sno cluster
+  cleanup_script: ../scripts/delete_cluster.sh
   conversation:
     - eval_id: create_eval_test_sno
-      eval_query: create a new single node cluster named eval-test-static-net-cluster, running on version 4.19.7 with the x86_64 CPU architecture, configured under the base domain example.com, without an ssh key.
-      eval_types: [tool_eval]
+      eval_query: create a new single node cluster named eval-test-static-net-cluster-uniq-cluster-name, running on version 4.19.7 with the x86_64 CPU architecture, configured under the base domain example.com, without an ssh key.
+      eval_types: [tool_eval, action_eval]
+      eval_verify_script: ../scripts/cluster_created_check.sh
       expected_tool_calls:
         - - tool_name: create_cluster
             arguments:
-              name: "eval-test-static-net-cluster"
+              name: "eval-test-static-net-cluster-uniq-cluster-name"
               version: "4\\.19\\.7"
               base_domain: "example\\.com"
               single_node: "(?i:true)"
               cpu_architecture: "x86_64"
-              ssh_public_key: null
+              ssh_public_key: ""
+              platform: "none"
     - eval_id: configure_hosts
       eval_query: |
-        I want to configure static networking. Create configs for two hosts: both have a single vlan interface backed by an ethernet interface.  The first has an ethernet interface with mac address c5:d6:bc:f0:05:20, and the vlan interface has ip address 10.0.0.5/24. The second has an ethernet mac address of a0:a9:b6:81:c7:a6 and a vlan ip address of 10.0.0.6/24. The vlan id for both is 400. Use the name eth0 for the ethernet interface and vlan0 as the name of the vlan interface for both hosts. Also I want DNS config for both of these configs with a DNS server 8.8.8.8.
+        I want to configure static networking. Create configs with a single vlan interface backed by an ethernet interface. It should have an ethernet interface with mac address c5:d6:bc:f0:05:20, and the vlan interface has ip address 10.0.0.5/24. The vlan id is 400. Use the name eth0 for the ethernet interface and vlan0 as the name of the vlan interface. Also I want DNS config with a DNS server 8.8.8.8.
       eval_types: [tool_eval]
       expected_tool_calls:
         - - tool_name: generate_nmstate_yaml
             arguments: 
               params: |-
                 \{"ethernet_ifaces": \[\{"mac_address": "c5:d6:bc:f0:05:20", "name": "eth0"}\], "vlan_ifaces": \[{"name": "vlan0", "vlan_id": 400, "base_interface_name": "eth0", "ipv4_address": {"address": "10.0.0.5", "cidr_length": 24}}\], "dns": {"dns_servers": \["8.8.8.8"\]}}
-        - - tool_name: generate_nmstate_yaml
-            arguments: 
-              params: |-
-                {"ethernet_ifaces": \[{"mac_address": "a0:a9:b6:81:c7:a6", "name": "eth0"}\], "vlan_ifaces": \[{"name": "vlan0", "vlan_id": 400, "base_interface_name": "eth0", "ipv4_address": {"address": "10.0.0.6", "cidr_length": 24}}\], "dns": {"dns_servers": \["8.8.8.8"\]}}
     - eval_id: apply_to_cluster
-      eval_query: Yes, apply it to the cluster.
+      eval_query: Yes, apply it to the cluster you just created.
       eval_types: [tool_eval]
       expected_tool_calls:
         - - tool_name: alter_static_network_config_nmstate_for_host
@@ -225,8 +225,3 @@
               cluster_id: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
               index: null
               new_nmstate_yaml: "10.0.0.5"
-        - - tool_name: alter_static_network_config_nmstate_for_host
-            arguments:
-              cluster_id: "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
-              index: null
-              new_nmstate_yaml: "10.0.0.6"

--- a/test/prow/Dockerfile
+++ b/test/prow/Dockerfile
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi9/python-311:latest
 
 USER 0
-RUN yum install -y jq patch
+RUN yum install -y jq patch vim
 RUN pip install yq
 RUN pip install git+https://github.com/lightspeed-core/lightspeed-evaluation.git#subdirectory=lsc_agent_eval
 RUN mkdir -p /opt/app-root/src
 WORKDIR /opt/app-root/src
 COPY . .
 RUN chmod 755 test/prow/entrypoint.sh
+RUN chmod 755 test/scripts/*.sh

--- a/test/prow/entrypoint.sh
+++ b/test/prow/entrypoint.sh
@@ -4,12 +4,13 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-
-OCM_TOKEN=$(curl -X POST https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token \
+: "${UNIQUE_ID:?UNIQUE_ID is required}"
+OCM_TOKEN=$(curl -sSf -X POST https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" \
   -d "client_id=$CLIENT_ID" \
-  -d "client_secret=$CLIENT_SECRET" | jq '.access_token' | sed "s/^['\"]*//; s/['\"]*$//")
+  -d "client_secret=$CLIENT_SECRET" | jq -r '.access_token')
+export OCM_TOKEN
 
 WORK_DIR=$(pwd)
 TEST_DIR="${WORK_DIR}/test/evals"
@@ -22,5 +23,6 @@ echo "GEMINI_API_KEY=${GEMINI_API_KEY}" > .env
 
 cp $TEST_DIR/eval_data.yaml $TEMP_DIR/eval_data.yaml
 sed -i "s/uniq-cluster-name/${UNIQUE_ID}/g" $TEMP_DIR/eval_data.yaml
+sed -i "s|: ../scripts|: ${WORK_DIR}/test/scripts|g" $TEMP_DIR/eval_data.yaml
 
-python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEMP_DIR/ocm_token.txt --eval_data_yaml $TEST_DIR/eval_data.yaml --eval_data_yaml $TEMP_DIR/eval_data.yaml
+python $TEST_DIR/eval.py --agent_endpoint "${AGENT_URL}:${AGENT_PORT}" --agent_auth_token_file $TEMP_DIR/ocm_token.txt --eval_data_yaml $TEMP_DIR/eval_data.yaml

--- a/test/prow/template.yaml
+++ b/test/prow/template.yaml
@@ -43,6 +43,8 @@ objects:
             value: ${AGENT_PORT}
           - name: UNIQUE_ID
             value: ${JOB_ID}
+          - name: OCM_BASE_URL
+            value: ${OCM_BASE_URL}
 
 parameters:
 - name: JOB_ID
@@ -64,3 +66,5 @@ parameters:
   value: gemini
 - name: GEMINI_API_SECRET_KEY_NAME
   value: api_key
+- name: OCM_BASE_URL
+  value: https://api.stage.openshift.com

--- a/test/scripts/cluster_create_test_setup.sh
+++ b/test/scripts/cluster_create_test_setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: "${OCM_TOKEN:?OCM_TOKEN is required}"
+: "${UNIQUE_ID:?UNIQUE_ID is required}"
+OCM_BASE_URL=${OCM_BASE_URL:-https://api.stage.openshift.com}
+ASSISTED_SERVICE_URL="${OCM_BASE_URL}/api/assisted-install/v2"
+
+PULL_SECRET_RAW="$(
+  curl -sSf -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${OCM_TOKEN}" \
+    "${OCM_BASE_URL}/api/accounts_mgmt/v1/access_token"
+)"
+
+CLUSTER_PAYLOAD="$(
+  jq -n \
+    --arg name "eval-testcluster-${UNIQUE_ID}" \
+    --arg version "4.18.22" \
+    --arg pull_secret "$PULL_SECRET_RAW" \
+    --arg base_dns_domain "test.local" \
+    --argjson control_plane_count 1 \
+    '{name:$name, control_plane_count:$control_plane_count, openshift_version:$version, pull_secret:$pull_secret, base_dns_domain:$base_dns_domain}'
+)"
+
+CLUSTER_ID="$(
+  curl -sSf -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${OCM_TOKEN}" \
+    -d "${CLUSTER_PAYLOAD}" \
+    "${ASSISTED_SERVICE_URL}/clusters" | jq -r '.id'
+)"
+
+INFRA_PAYLOAD="$(
+  jq -n \
+    --arg name "eval-testcluster-${UNIQUE_ID}_infra-env" \
+    --arg pull_secret "$PULL_SECRET_RAW" \
+    --arg cluster_id "$CLUSTER_ID" \
+    --arg openshift_version "4.18.22" \
+    '{name:$name, pull_secret:$pull_secret, cluster_id:$cluster_id, openshift_version:$openshift_version}'
+)"
+
+curl -sSf -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${OCM_TOKEN}" \
+  -d "${INFRA_PAYLOAD}" \
+  "${ASSISTED_SERVICE_URL}/infra-envs"
+
+
+
+
+COUNTER=0
+while ! curl -sSf -H "Authorization: Bearer ${OCM_TOKEN}" "${ASSISTED_SERVICE_URL}/clusters/${CLUSTER_ID}"; do
+    if [[ $COUNTER -gt 3 ]]; then
+        echo "Cluster creation timed out"
+        exit 1
+    fi
+    ((COUNTER++))
+    sleep 10
+done

--- a/test/scripts/cluster_created_check.sh
+++ b/test/scripts/cluster_created_check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: "${OCM_TOKEN:?OCM_TOKEN is required}"
+: "${UNIQUE_ID:?UNIQUE_ID is required}"
+ASSISTED_SERVICE_URL="${OCM_BASE_URL:-https://api.stage.openshift.com}/api/assisted-install/v2"
+
+COUNTER=0
+while ! curl -sSf -H "Authorization: Bearer ${OCM_TOKEN}" "${ASSISTED_SERVICE_URL}/clusters" | grep "${UNIQUE_ID}"; do
+    if [[ $COUNTER -gt 3 ]]; then
+        echo "Cluster creation timed out"
+        exit 1
+    fi
+    ((COUNTER++))
+    sleep 10
+done
+
+echo "The cluster was successfully created by the eval test using the mcp tool call."

--- a/test/scripts/delete_cluster.sh
+++ b/test/scripts/delete_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: "${OCM_TOKEN:?OCM_TOKEN is required}"
+: "${UNIQUE_ID:?UNIQUE_ID is required}"
+ASSISTED_SERVICE_URL="${OCM_BASE_URL:-https://api.stage.openshift.com}/api/assisted-install/v2"
+
+curl -fsS -H "Authorization: Bearer ${OCM_TOKEN}" "${ASSISTED_SERVICE_URL}/clusters" | jq '[.[] |{id, name}]' | jq -c '.[]' | while read item; do
+  id=$(echo "$item" | jq -r '.id')
+  name=$(echo "$item" | jq -r '.name')
+  if [[ "$name" == *"-${UNIQUE_ID}" ]]; then
+    echo "The cluster '${name}', ${id} is going to be deleted"
+    curl -fsS -X DELETE -H "Authorization: Bearer ${OCM_TOKEN}" "${ASSISTED_SERVICE_URL}/clusters/${id}"
+  fi
+done


### PR DESCRIPTION
Updating the query in several evaluation tests so the instructions would be more straightforward.
Adding a post script to the test which create a cluster, what deletes the created cluster - it helps reducing the number of clusters in the pool, which makes the environment for the tests more uniform.
Updating the test cluster_id_from_name with a setup script which creates a cluster, because when the chat is used to create the cluster then mostly it simply just remembers the UUID of the created cluster.
Also adding a check which verifies if the cluster was really created, because the proper tool call is only half of the acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enforced UNIQUE_ID precondition, clearer success banner, and stricter failure detection for evaluations.

- Tests
  - Expanded evaluation scenarios: action evaluations, setup/verify/cleanup hooks, updated cluster naming/network flows, refined cloud-refusal behavior and verification steps.

- Chores
  - CI/test tooling improvements: safer token handling, isolated temp-dir runs, executable test scripts, added env vars for OCM endpoints and pull-secret access, new Makefile test targets, and cluster lifecycle helper scripts.

- Documentation
  - Clarified cluster-name-to-ID matching workflow and provider guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->