### PR TITLE
Adjust `build-images.sh` to comment out also `==`

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -83,11 +83,11 @@ function build_lightspeed_stack() {
     pushd "${PROJECT_ROOT}/lightspeed-stack"
     # Comment out the llama-stack dependency in pyproject.toml so it uses the locally installed version
     # instead
-    sed -i '/^[^#].*llama-stack[[:space:]]*>=/ s/^/# /' pyproject.toml
+    sed -i '/^[^#].*llama-stack[[:space:]]*[>=|==]/ s/^/# /' pyproject.toml
     uv lock
     podman build -f Containerfile . --tag localhost/local-ai-chat-lightspeed-stack:latest
     # Undo it
-    sed -i 's/^# \(.*llama-stack[[:space:]]*>=.*\)$/\1/' pyproject.toml
+    sed -i 's/^# \(.*llama-stack[[:space:]]*[>=|==].*\)$/\1/' pyproject.toml
     # uv.lock is guaranteed to change, and it's annoying to have it as a dirty file, so let's restore it
     git checkout uv.lock 2>/dev/null || true  # Don't fail if uv.lock doesn't exist in git
     popd


### PR DESCRIPTION
When building the local dev images, we force `lightspeed-stack` to use the locally installed `llama-stack` by commenting out the dependency in `pyproject.toml`. However, the current regex only matches `>=` and misses `==`. This change updates the regex to match both `>=` and `==` to ensure all relevant dependency specifications are commented out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build tooling now correctly handles both minimum (>=) and exact (==) version specifications for a dependency when toggling to a local version, preventing failures with pinned versions.
* **Chores**
  * Improved reliability of the image build process with broader version-spec support.
  * No changes to application behavior; end-user functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->