### PR TITLE
setup_secrets.sh shall print only the path

### DIFF
--- a/scripts/setup_secrets.sh
+++ b/scripts/setup_secrets.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # This script handles setting up the secrets directory, either using a local
 # VERTEX_SERVICE_ACCOUNT_PATH or the default /var/run/secrets path
 
-echo "Setting up secrets directory"
+echo "Setting up secrets directory" >&2
 
 # Set default secrets base path
 SECRETS_BASE_PATH="${SECRETS_BASE_PATH:-/var/run/secrets}"


### PR DESCRIPTION
This is a quick fix in the secrets setup script that currently causes the following error when testing the local-dev workflow in CI:
`ls: cannot access 'Setting up secrets directory'$'\n''/var/run/secrets': No such file or directory`

The script supposed to print only the secrets path without any extra messages, so it can be processed in the Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the initial setup message to print to the error stream instead of standard output during secrets setup. This keeps stdout clean for data consumption, reduces noise in pipelines, and prevents logs from being mistaken for output by scripts or redirects. No functional behavior changed—only the destination of the message—resulting in clearer logs and more reliable automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->