### PR TITLE
Allow service account tokens for local dev auth

### DIFF
--- a/template-params.dev.env
+++ b/template-params.dev.env
@@ -6,5 +6,5 @@ LIGHTSPEED_FEEDBACK_ENABLED=false
 DISABLE_QUERY_SYSTEM_PROMPT=false
 ASSISTED_CHAT_DEFAULT_MODEL=gemini/gemini-2.0-flash
 LIGHTSPEED_STACK_POSTGRES_SSL_MODE=disable
-AUTHN_ROLE_RULES='[{"jsonpath":"$.realm_access.roles[*]","operator":"contains","value":"redhat:employees","roles":["redhat_employee"]},{"jsonpath":"$.email","operator":"match","value":".*@redhat\\\\.com$","roles":["redhat_employee"]}]'
+AUTHN_ROLE_RULES='[{"jsonpath":"$.realm_access.roles[*]","operator":"contains","value":"redhat:employees","roles":["redhat_employee"]},{"jsonpath":"$.email","operator":"match","value":".*@redhat\\\\.com$","roles":["redhat_employee"]}, {"jsonpath":"$.preferred_username","operator":"match","value":"service-account.*$","roles":["redhat_employee"]}]'
 AUTHZ_ACCESS_RULES='[{"role":"redhat_employee","actions":["get_models","query","streaming_query","get_conversation","list_conversations","delete_conversation","feedback","info","get_metrics", "get_config", "model_override"]}]'


### PR DESCRIPTION
This is to help when using the assisted-installer read-only account for troubleshooting work. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically assigns the Red Hat Employee role to service accounts whose usernames match the service-account pattern, improving access consistency for automated users.

- Chores
  - Updated environment configuration to support the new role-mapping rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->