### PR TITLE
update rpms-signature-scan task

### DIFF
--- a/.tekton/assisted-chat-saas-main-pull-request.yaml
+++ b/.tekton/assisted-chat-saas-main-pull-request.yaml
@@ -598,7 +598,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0eb4cfb41181a158b6761c990cc7a9f7f77c70f7ff19bf276009c6ef59c9da5e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-chat-saas-main-pull-request.yaml
+++ b/.tekton/assisted-chat-saas-main-pull-request.yaml
@@ -598,7 +598,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:fb6c97a57e221fa106a8b45be3e12c49e7124a3a8e2a0f0d5fbaeb17b5bf68a5
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-chat-saas-main-push.yaml
+++ b/.tekton/assisted-chat-saas-main-push.yaml
@@ -592,7 +592,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0eb4cfb41181a158b6761c990cc7a9f7f77c70f7ff19bf276009c6ef59c9da5e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-chat-saas-main-push.yaml
+++ b/.tekton/assisted-chat-saas-main-push.yaml
@@ -592,7 +592,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
```
  Results:
  ✕ [Violation] tasks.required_untrusted_task_found
    ImageRef: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-chat-saas-main/assisted-chat-saas-main@sha256:3b0bff864cab37ab61df9c0d84925b5e1222bca39fe9f478d6fa8a406ec3d2c1
    Reason: Required task "rpms-signature-scan" is required and present but not from a trusted task
    Term: rpms-signature-scan
    Title: All required tasks are from trusted tasks
    Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
    "tasks.required_untrusted_task_found:rpms-signature-scan" to the `exclude` section of the policy configuration.
    Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
  
  ✕ [Violation] trusted_task.trusted
    ImageRef: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-chat-saas-main/assisted-chat-saas-main@sha256:3b0bff864cab37ab61df9c0d84925b5e1222bca39fe9f478d6fa8a406ec3d2c1
    Reason: Untrusted version of PipelineTask "rpms-signature-scan" (Task "rpms-signature-scan") was included in build chain
    comprised of: rpms-signature-scan. Please upgrade the task version to:
    sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
    Term: rpms-signature-scan
    Title: Tasks are trusted
    Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
    first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
    creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
    fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
    this rule add "trusted_task.trusted:rpms-signature-scan" to the `exclude` section of the policy configuration.
    Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
    trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
    when newer versions are made available.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration pipeline security scanning components to newer versions for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->