### PR TITLE
Update default eval model to gemini-3.5-flash

### DIFF
--- a/test/evals/eval.py
+++ b/test/evals/eval.py
@@ -50,8 +50,8 @@ def parse_args():
 
     parser.add_argument(
         "--agent_model",
-        default="gemini-2.5-flash",
-        help="Agent model (default: gemini-2.5-flash)",
+        default="gemini-3.5-flash",
+        help="Agent model (default: gemini-3.5-flash)",
     )
 
     parser.add_argument(
@@ -62,8 +62,8 @@ def parse_args():
 
     parser.add_argument(
         "--judge_model",
-        default="gemini-2.5-flash",
-        help="Judge model for LLM evaluation (default: gemini-2.5-flash)",
+        default="gemini-3.5-flash",
+        help="Judge model for LLM evaluation (default: gemini-3.5-flash)",
     )
 
     parser.add_argument(


### PR DESCRIPTION
gemini-2.5-flash now returns 404 for new API keys/projects ("no longer available to new users"), even though the official retirement date is October 16, 2026. Switch the agent/judge model defaults used in eval.py to gemini-3.5-flash, Google's documented recommended replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AI models used for agent evaluations and result judging.
  * Evaluation workflows and failure handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->